### PR TITLE
Feature OAPH From Observable Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # ReactiveUI.SourceGenerators
-Use source generators to generate ReactiveUI objects. 
-
-Not taking public contributions at this time
+Use source generators to generate ReactiveUI objects.
 
 These Source Generators were designed to work in full with ReactiveUI V19.5.31 and newer supporting all features, currently:
 - [Reactive]
 - [ObservableAsProperty]
+- [ObservableAsProperty(PropertyName = "ReadOnlyPropertyName")]
 - [ReactiveCommand]
 - [ReactiveCommand(CanExecute = nameof(IObservableBoolName))] with CanExecute
 - [ReactiveCommand][property: AttribueToAddToCommand] with Attribute passthrough
@@ -75,6 +74,8 @@ public partial class MyReactiveClass : ReactiveObject
 ```
 
 ## Usage ObservableAsPropertyHelper `[ObservableAsProperty]`
+
+### Usage ObservableAsPropertyHelper with Field
 ```csharp
 using ReactiveUI.SourceGenerators;
 
@@ -90,6 +91,80 @@ public partial class MyReactiveClass : ReactiveObject
     }
 
     IObservable<string> MyPropertyObservable() => Observable.Return("Test Value");
+}
+```
+
+### Usage ObservableAsPropertyHelper with Observable Property
+```csharp
+using ReactiveUI.SourceGenerators;
+
+public partial class MyReactiveClass : ReactiveObject
+{    
+    public MyReactiveClass()
+    { 
+        // Initialize generated _myObservablePropertyHelper
+        // for the generated MyObservableProperty
+        InitializeOAPH();
+    }
+
+    [ObservableAsProperty]
+    IObservable<string> MyObservable => Observable.Return("Test Value");
+}
+```
+
+### Usage ObservableAsPropertyHelper with Observable Property and specific PropertyName
+```csharp
+using ReactiveUI.SourceGenerators;
+
+public partial class MyReactiveClass : ReactiveObject
+{    
+    public MyReactiveClass()
+    { 
+        // Initialize generated _testValuePropertyHelper
+        // for the generated TestValueProperty
+        InitializeOAPH();
+    }
+
+    [ObservableAsProperty(PropertyName = TestValueProperty)]
+    IObservable<string> MyObservable => Observable.Return("Test Value");
+}
+```
+
+### Usage ObservableAsPropertyHelper with Observable Method
+
+NOTE: This does not support methods with parameters
+```csharp
+using ReactiveUI.SourceGenerators;
+
+public partial class MyReactiveClass : ReactiveObject
+{    
+    public MyReactiveClass()
+    { 
+        // Initialize generated _myObservablePropertyHelper
+        // for the generated MyObservableProperty
+        InitializeOAPH();
+    }
+
+    [ObservableAsProperty]
+    IObservable<string> MyObservable() => Observable.Return("Test Value");
+}
+```
+
+### Usage ObservableAsPropertyHelper with Observable Method and specific PropertyName
+```csharp
+using ReactiveUI.SourceGenerators;
+
+public partial class MyReactiveClass : ReactiveObject
+{    
+    public MyReactiveClass()
+    { 
+        // Initialize generated _testValuePropertyHelper
+        // for the generated TestValueProperty
+        InitializeOAPH();
+    }
+
+    [ObservableAsProperty(PropertyName = TestValueProperty)]
+    IObservable<string> MyObservable() => Observable.Return("Test Value");
 }
 ```
 
@@ -291,4 +366,4 @@ public partial class MyReactiveControl : UserControl
 ```
 
 ### TODO:
-- Add ObservableAsProperty to generate from a IObservable creating a property and the property helper wired to the Observable.
+- Add ObservableAsProperty to generate from a IObservable method with parameters.

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ The class must inherit from a UI Control from any of the following platforms and
 ```csharp
 using ReactiveUI.SourceGenerators;
 
-[IViewFor(MyReactiveClass)]
+[IViewFor(nameof(MyReactiveClass))]
 public partial class MyReactiveControl : UserControl
 {
     public MyReactiveControl()

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -60,7 +60,8 @@ public partial class TestViewModel : ReactiveObject
         Test8ObservableCommand?.Execute(100).Subscribe(Console.Out.WriteLine);
         Console.Out.WriteLine($"Test2Property Value: {Test2Property}");
         Console.Out.WriteLine($"Test2Property underlying Value: {_test2Property}");
-
+        Console.Out.WriteLine(ObservableAsPropertyTest2Property);
+        Console.Out.WriteLine(MyReadOnlyProperty);
         Test9AsyncCommand?.ThrownExceptions.Subscribe(Console.Out.WriteLine);
         var cancel = Test9AsyncCommand?.Execute().Subscribe();
         Task.Delay(1000).Wait();
@@ -94,9 +95,16 @@ public partial class TestViewModel : ReactiveObject
     /// <value>
     /// The can execute test1.
     /// </value>
-#pragma warning disable CA1822 // Mark members as static
-    public IObservable<bool> CanExecuteTest1 => Observable.Return(true);
-#pragma warning restore CA1822 // Mark members as static
+    public IObservable<bool> CanExecuteTest1 => ObservableAsPropertyTest2.Select(x => x > 0);
+
+    /// <summary>
+    /// Gets the observable as property test2.
+    /// </summary>
+    /// <value>
+    /// The observable as property test2.
+    /// </value>
+    [ObservableAsProperty]
+    public IObservable<int> ObservableAsPropertyTest2 => Observable.Return(9);
 
     /// <summary>
     /// Gets observables as property test.
@@ -113,7 +121,7 @@ public partial class TestViewModel : ReactiveObject
     [ReactiveCommand(CanExecute = nameof(CanExecuteTest1))]
     [property: JsonInclude]
     [property: Test(AParameter = "Test Input")]
-    private void Test1() => Console.Out.WriteLine("Test1");
+    private void Test1() => Console.Out.WriteLine("Test1 Command Executed");
 
     /// <summary>
     /// Test3s the asynchronous.

--- a/src/ReactiveUI.SourceGenerators/Diagnostics/SuppressionDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators/Diagnostics/SuppressionDescriptors.cs
@@ -22,7 +22,7 @@ internal static class SuppressionDescriptors
     public static readonly SuppressionDescriptor ReactiveCommandDoesNotAccessInstanceData = new(
         id: "RXUISPR0003",
         suppressedDiagnosticId: "CA1822",
-        justification: "Methods using [ReactiveCommand] do not need to be static");
+        justification: "Methods using [ReactiveCommand] or [ObservableAsProperty] do not need to be static");
 
     public static readonly SuppressionDescriptor ReactiveFieldsShouldNotBeReadOnly = new(
         id: "RXUISPR0004",

--- a/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ObservableAsPropertyAttributeWithFieldNeverReadDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ObservableAsPropertyAttributeWithFieldNeverReadDiagnosticSuppressor.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ReactiveUI.SourceGenerators.Extensions;
+using ReactiveUI.SourceGenerators.Helpers;
 using static ReactiveUI.SourceGenerators.Diagnostics.SuppressionDescriptors;
 
 namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions
@@ -40,7 +41,7 @@ namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions
 
                     // Check if the method is using [ObservableAsProperty], in which case we should suppress the warning
                     if (declaredSymbol is IMethodSymbol methodSymbol &&
-                        semanticModel.Compilation.GetTypeByMetadataName("ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute") is INamedTypeSymbol reactiveCommandSymbol &&
+                        semanticModel.Compilation.GetTypeByMetadataName(AttributeDefinitions.ObservableAsPropertyAttributeType) is INamedTypeSymbol reactiveCommandSymbol &&
                         methodSymbol.HasAttributeWithType(reactiveCommandSymbol))
                     {
                         context.ReportSuppression(Suppression.Create(FieldIsUsedToGenerateAObservableAsPropertyHelper, diagnostic));

--- a/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ReactiveCommandAttributeWithFieldOrPropertyTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ReactiveCommandAttributeWithFieldOrPropertyTargetDiagnosticSuppressor.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ReactiveUI.SourceGenerators.Extensions;
+using ReactiveUI.SourceGenerators.Helpers;
 using static ReactiveUI.SourceGenerators.Diagnostics.SuppressionDescriptors;
 
 namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions
@@ -40,7 +41,7 @@ namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions
 
                     // Check if the method is using [ReactiveCommand], in which case we should suppress the warning
                     if (declaredSymbol is IMethodSymbol methodSymbol &&
-                        semanticModel.Compilation.GetTypeByMetadataName("ReactiveUI.SourceGenerators.ReactiveCommandAttribute") is INamedTypeSymbol reactiveCommandSymbol &&
+                        semanticModel.Compilation.GetTypeByMetadataName(AttributeDefinitions.ReactiveCommandAttributeType) is INamedTypeSymbol reactiveCommandSymbol &&
                         methodSymbol.HasAttributeWithType(reactiveCommandSymbol))
                     {
                         context.ReportSuppression(Suppression.Create(FieldOrPropertyAttributeListForReactiveCommandMethod, diagnostic));

--- a/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ReactiveUI.SourceGenerators.Extensions;
+using ReactiveUI.SourceGenerators.Helpers;
 using static ReactiveUI.SourceGenerators.Diagnostics.SuppressionDescriptors;
 
 namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions;
@@ -40,7 +41,7 @@ public sealed class ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppress
 
                 // Check if the method is using [ReactiveCommand], in which case we should suppress the warning
                 if (declaredSymbol is IMethodSymbol methodSymbol &&
-                    semanticModel.Compilation.GetTypeByMetadataName("ReactiveUI.SourceGenerators.ReactiveCommandAttribute") is INamedTypeSymbol reactiveCommandSymbol &&
+                    semanticModel.Compilation.GetTypeByMetadataName(AttributeDefinitions.ReactiveCommandAttributeType) is INamedTypeSymbol reactiveCommandSymbol &&
                     methodSymbol.HasAttributeWithType(reactiveCommandSymbol))
                 {
                     context.ReportSuppression(Suppression.Create(ReactiveCommandDoesNotAccessInstanceData, diagnostic));

--- a/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ReactiveFieldDoesNotNeedToBeReadOnlyDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators/Diagnostics/Suppressions/ReactiveFieldDoesNotNeedToBeReadOnlyDiagnosticSuppressor.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ReactiveUI.SourceGenerators.Extensions;
+using ReactiveUI.SourceGenerators.Helpers;
 using static ReactiveUI.SourceGenerators.Diagnostics.SuppressionDescriptors;
 
 namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions
@@ -40,7 +41,7 @@ namespace ReactiveUI.SourceGenerators.Diagnostics.Suppressions
 
                     // Check if the method is using [Reactive], in which case we should suppress the warning
                     if (declaredSymbol is IFieldSymbol fieldSymbol &&
-                        semanticModel.Compilation.GetTypeByMetadataName("ReactiveUI.SourceGenerators.ReactiveAttribute") is INamedTypeSymbol reactiveSymbol &&
+                        semanticModel.Compilation.GetTypeByMetadataName(AttributeDefinitions.ReactiveAttributeType) is INamedTypeSymbol reactiveSymbol &&
                         fieldSymbol.HasAttributeWithType(reactiveSymbol))
                     {
                         context.ReportSuppression(Suppression.Create(ReactiveFieldsShouldNotBeReadOnly, diagnostic));

--- a/src/ReactiveUI.SourceGenerators/Helpers/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators/Helpers/AttributeDefinitions.cs
@@ -9,6 +9,8 @@ namespace ReactiveUI.SourceGenerators.Helpers;
 
 internal static class AttributeDefinitions
 {
+    public const string GeneratedCode = "global::System.CodeDom.Compiler.GeneratedCode";
+    public const string ExcludeFromCodeCoverage = "global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage";
     public const string ReactiveObjectAttribute = """
 // Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
@@ -33,6 +35,7 @@ public sealed class ReactiveObjectAttribute : Attribute;
 #pragma warning restore
 """;
 
+    public const string ReactiveCommandAttributeType = "ReactiveUI.SourceGenerators.ReactiveCommandAttribute";
     public const string ReactiveCommandAttribute = """
 // Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
@@ -66,6 +69,7 @@ public sealed class ReactiveCommandAttribute : Attribute
 #pragma warning restore
 """;
 
+    public const string ReactiveAttributeType = "ReactiveUI.SourceGenerators.ReactiveAttribute";
     public const string ReactiveAttribute = """
 // Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
@@ -90,6 +94,7 @@ public sealed class ReactiveAttribute : Attribute;
 #pragma warning restore
 """;
 
+    public const string ObservableAsPropertyAttributeType = "ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute";
     public const string ObservableAsPropertyAttribute = """
 // Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
@@ -104,11 +109,11 @@ using System;
 namespace ReactiveUI.SourceGenerators;
 
 /// <summary>
-/// ReactivePropertyAttribute.
+/// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
 [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
-[AttributeUsage(AttributeTargets.Field | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 public sealed class ObservableAsPropertyAttribute : Attribute
 {
     /// <summary>
@@ -123,6 +128,7 @@ public sealed class ObservableAsPropertyAttribute : Attribute
 #pragma warning restore
 """;
 
+    public const string IViewForAttributeType = "ReactiveUI.SourceGenerators.IViewForAttribute";
     public const string IViewForAttribute = """
 // Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
@@ -137,7 +143,7 @@ using System;
 namespace ReactiveUI.SourceGenerators;
 
 /// <summary>
-/// ReactiveObjectAttribute.
+/// IViewForAttribute.
 /// </summary>
 /// <seealso cref="System.Attribute" />
 /// <remarks>

--- a/src/ReactiveUI.SourceGenerators/IViewFor/IViewForGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators/IViewFor/IViewForGenerator.cs
@@ -17,7 +17,6 @@ using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 using ReactiveUI.SourceGenerators.Input.Models;
 using ReactiveUI.SourceGenerators.Models;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace ReactiveUI.SourceGenerators;
 
@@ -28,19 +27,18 @@ namespace ReactiveUI.SourceGenerators;
 public sealed partial class IViewForGenerator : IIncrementalGenerator
 {
     private const string GeneratedCode = "global::System.CodeDom.Compiler.GeneratedCode";
-    private const string IViewForAttribute = "ReactiveUI.SourceGenerators.IViewForAttribute";
 
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(ctx =>
-            ctx.AddSource($"{IViewForAttribute}.g.cs", SourceText.From(AttributeDefinitions.IViewForAttribute, Encoding.UTF8)));
+            ctx.AddSource($"{AttributeDefinitions.IViewForAttributeType}.g.cs", SourceText.From(AttributeDefinitions.IViewForAttribute, Encoding.UTF8)));
 
         // Gather info for all annotated IViewFor Classes
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, Result<IViewForInfo> Info)> iViewForInfoWithErrors =
             context.SyntaxProvider
             .ForAttributeWithMetadataName(
-                IViewForAttribute,
+                AttributeDefinitions.IViewForAttributeType,
                 static (node, _) => node is ClassDeclarationSyntax { AttributeLists.Count: > 0 },
                 static (context, token) =>
                 {
@@ -55,7 +53,7 @@ public sealed partial class IViewForGenerator : IIncrementalGenerator
                         var compilation = context.SemanticModel.Compilation;
                         var semanticModel = compilation.GetSemanticModel(context.SemanticModel.SyntaxTree);
                         var symbol = ModelExtensions.GetDeclaredSymbol(semanticModel, declaredClass, token)!;
-                        if (symbol.TryGetAttributeWithFullyQualifiedMetadataName(IViewForAttribute, out var attributeData))
+                        if (symbol.TryGetAttributeWithFullyQualifiedMetadataName(AttributeDefinitions.IViewForAttributeType, out var attributeData))
                         {
                             token.ThrowIfCancellationRequested();
                             var classSymbol = symbol as INamedTypeSymbol;

--- a/src/ReactiveUI.SourceGenerators/ObservableAsProperty/Models/ObservableMethodInfo.cs
+++ b/src/ReactiveUI.SourceGenerators/ObservableAsProperty/Models/ObservableMethodInfo.cs
@@ -13,6 +13,7 @@ namespace ReactiveUI.SourceGenerators.ObservableAsProperty.Models
     ITypeSymbol MethodReturnType,
     ITypeSymbol? ArgumentType,
     string PropertyName,
+    bool IsProperty,
     EquatableArray<AttributeInfo> ForwardedPropertyAttributes)
     {
         public string GetObservableTypeText() => MethodReturnType is not INamedTypeSymbol typeSymbol

--- a/src/ReactiveUI.SourceGenerators/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/Reactive/ReactiveGenerator.Execute.cs
@@ -25,9 +25,6 @@ namespace ReactiveUI.SourceGenerators;
 /// <seealso cref="IIncrementalGenerator" />
 public partial class ReactiveGenerator
 {
-    private const string GeneratedCode = "global::System.CodeDom.Compiler.GeneratedCode";
-    private const string ExcludeFromCodeCoverage = "global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage";
-
     /// <summary>
     /// A container for all the logic for <see cref="ReactiveCommandGenerator"/>.
     /// </summary>
@@ -123,12 +120,12 @@ public partial class ReactiveGenerator
                 PropertyDeclaration(propertyType, Identifier(propertyInfo.PropertyName))
                 .AddAttributeLists(
                     AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName(GeneratedCode))
+                        Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
                         .AddArgumentListArguments(
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ReactiveGenerator).FullName))),
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ReactiveGenerator).Assembly.GetName().Version.ToString()))))))
                     .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
-                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName(ExcludeFromCodeCoverage)))))
+                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName(AttributeDefinitions.ExcludeFromCodeCoverage)))))
                 .AddAttributeLists([.. forwardedAttributes])
                 .AddModifiers(Token(SyntaxKind.PublicKeyword))
                 .AddAccessorListAccessors(

--- a/src/ReactiveUI.SourceGenerators/Reactive/ReactiveGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators/Reactive/ReactiveGenerator.cs
@@ -23,19 +23,17 @@ namespace ReactiveUI.SourceGenerators;
 [Generator(LanguageNames.CSharp)]
 public sealed partial class ReactiveGenerator : IIncrementalGenerator
 {
-    private const string ReactiveAttribute = "ReactiveUI.SourceGenerators.ReactiveAttribute";
-
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(ctx =>
-            ctx.AddSource($"{ReactiveAttribute}.g.cs", SourceText.From(AttributeDefinitions.ReactiveAttribute, Encoding.UTF8)));
+            ctx.AddSource($"{AttributeDefinitions.ReactiveAttributeType}.g.cs", SourceText.From(AttributeDefinitions.ReactiveAttribute, Encoding.UTF8)));
 
         // Gather info for all annotated command methods (starting from method declarations with at least one attribute)
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, Result<PropertyInfo> Info)> propertyInfoWithErrors =
             context.SyntaxProvider
             .ForAttributeWithMetadataName(
-                ReactiveAttribute,
+                AttributeDefinitions.ReactiveAttributeType,
                 static (node, _) => node is VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax { Parent: FieldDeclarationSyntax { Parent: ClassDeclarationSyntax or RecordDeclarationSyntax, AttributeLists.Count: > 0 } } },
                 static (context, token) =>
                 {

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -27,12 +27,9 @@ public partial class ReactiveCommandGenerator
     private const string ReactiveUI = "ReactiveUI";
     private const string ReactiveCommand = "ReactiveCommand";
     private const string RxCmd = ReactiveUI + "." + ReactiveCommand;
-    private const string RxCmdAttribute = "ReactiveUI.SourceGenerators.ReactiveCommandAttribute";
     private const string Create = ".Create";
     private const string CreateO = ".CreateFromObservable";
     private const string CreateT = ".CreateFromTask";
-    private const string GeneratedCode = "global::System.CodeDom.Compiler.GeneratedCode";
-    private const string ExcludeFromCodeCoverage = "global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage";
 
     /// <summary>
     /// A container for all the logic for <see cref="ReactiveCommandGenerator"/>.
@@ -68,11 +65,11 @@ public partial class ReactiveCommandGenerator
                     Identifier("InitializeCommands"))
                 .AddAttributeLists(
                     AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName(GeneratedCode))
+                        Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
                         .AddArgumentListArguments(
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ReactiveGenerator).FullName))),
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ReactiveGenerator).Assembly.GetName().Version.ToString())))))),
-                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName(ExcludeFromCodeCoverage)))))
+                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName(AttributeDefinitions.ExcludeFromCodeCoverage)))))
                 .WithModifiers(TokenList(Token(SyntaxKind.ProtectedKeyword)))
                 .WithBody(Block(commandInitilisers.ToImmutable()));
 

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.cs
@@ -29,13 +29,13 @@ public sealed partial class ReactiveCommandGenerator : IIncrementalGenerator
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         context.RegisterPostInitializationOutput(ctx =>
-            ctx.AddSource($"{RxCmdAttribute}.g.cs", SourceText.From(AttributeDefinitions.ReactiveCommandAttribute, Encoding.UTF8)));
+            ctx.AddSource($"{AttributeDefinitions.ReactiveCommandAttributeType}.g.cs", SourceText.From(AttributeDefinitions.ReactiveCommandAttribute, Encoding.UTF8)));
 
         // Gather info for all annotated command methods (starting from method declarations with at least one attribute)
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, Result<CommandInfo> Info)> commandInfoWithErrors =
             context.SyntaxProvider
             .ForAttributeWithMetadataName(
-                RxCmdAttribute,
+                AttributeDefinitions.ReactiveCommandAttributeType,
                 static (node, _) => node is MethodDeclarationSyntax { Parent: ClassDeclarationSyntax or RecordDeclarationSyntax, AttributeLists.Count: > 0 },
                 static (context, token) =>
                 {
@@ -48,7 +48,7 @@ public sealed partial class ReactiveCommandGenerator : IIncrementalGenerator
                     token.ThrowIfCancellationRequested();
 
                     // Skip symbols without the target attribute
-                    if (!symbol.TryGetAttributeWithFullyQualifiedMetadataName(RxCmdAttribute, out var attributeData))
+                    if (!symbol.TryGetAttributeWithFullyQualifiedMetadataName(AttributeDefinitions.ReactiveCommandAttributeType, out var attributeData))
                     {
                         return default;
                     }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The OAPH Generator supports Fields and Observable Methods

**What is the new behavior?**
<!-- If this is a feature change -->

Support for Observable Properties added

**What might this PR break?**

N/A new feature

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:
A ReadOnly Property will be generated.
A OAPH Helper will be generated.
The generated Read Only Properties will be attached to the Observable upon calling `InitializeOAPH()`
If `PropertyName` is not set the Method Name is added to "Property" to make MethodNameProperty, otherwise the `PropertyName` property of the Attribute will be used as the base for generated elements.
Currently only parameter less Observable Methods and Properties are supported.