### PR TITLE
Declare command properties as notnull (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,11 +176,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private void Execute() { }
 }
@@ -192,11 +187,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private void Execute(string parameter) { }
 }
@@ -208,11 +198,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private string Execute(string parameter) => parameter;
 }
@@ -224,11 +209,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private async Task<string> Execute(string parameter) => await Task.FromResult(parameter);
 }
@@ -240,11 +220,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private IObservable<string> Execute(string parameter) => Observable.Return(parameter);
 }
@@ -256,11 +231,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private async Task Execute(CancellationToken token) => await Task.Delay(1000, token);
 }
@@ -272,11 +242,6 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    public MyReactiveClass()
-    {
-        InitializeCommands();
-    }
-
     [ReactiveCommand]
     private async Task<string> Execute(string parameter, CancellationToken token)
     {
@@ -302,7 +267,6 @@ public partial class MyReactiveClass
 
     public MyReactiveClass()
     {
-        InitializeCommands();
         _canExecute = this.WhenAnyValue(x => x.MyProperty1, x => x.MyProperty2, (x, y) => !string.IsNullOrEmpty(x) && !string.IsNullOrEmpty(y));
     }
 
@@ -327,7 +291,6 @@ public partial class MyReactiveClass
 
     public MyReactiveClass()
     {
-        InitializeCommands();
         _canExecute = this.WhenAnyValue(x => x.MyProperty1, x => x.MyProperty2, (x, y) => !string.IsNullOrEmpty(x) && !string.IsNullOrEmpty(y));
     }
 

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -33,7 +33,6 @@ public partial class TestViewModel : ReactiveObject
     /// </summary>
     public TestViewModel()
     {
-        InitializeCommands();
         InitializeOAPH();
 
         Console.Out.WriteLine(Test1Command);

--- a/src/ReactiveUI.SourceGenerators/Helpers/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators/Helpers/AttributeDefinitions.cs
@@ -11,6 +11,7 @@ internal static class AttributeDefinitions
 {
     public const string GeneratedCode = "global::System.CodeDom.Compiler.GeneratedCode";
     public const string ExcludeFromCodeCoverage = "global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage";
+    public const string Obsolete = "global::System.Obsolete";
     public const string ReactiveObjectAttribute = """
 // Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -37,9 +37,7 @@ public partial class ReactiveCommandGenerator
     /// </summary>
     internal static class Execute
     {
-        internal static MethodDeclarationSyntax GetCommandInitiliser()
-        {
-            return MethodDeclaration(
+        internal static MethodDeclarationSyntax GetCommandInitiliser() => MethodDeclaration(
                     PredefinedType(Token(SyntaxKind.VoidKeyword)),
                     Identifier("InitializeCommands"))
                 .AddAttributeLists(
@@ -54,7 +52,6 @@ public partial class ReactiveCommandGenerator
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(ObsoleteReason)))))))
                 .WithModifiers(TokenList(Token(SyntaxKind.ProtectedKeyword)))
                 .WithBody(Block());
-        }
 
         internal static MemberDeclarationSyntax[] GetCommandProperty(CommandInfo commandExtensionInfo)
         {
@@ -470,9 +467,7 @@ public partial class ReactiveCommandGenerator
             return $"{char.ToUpper(commandName[0], CultureInfo.InvariantCulture)}{commandName.Substring(1)}Command";
         }
 
-        internal static string GetGeneratedFieldName(string generatedCommandName)
-        {
-            return $"_{char.ToLower(generatedCommandName[0], CultureInfo.InvariantCulture)}{generatedCommandName.Substring(1)}";
-        }
+        internal static string GetGeneratedFieldName(string generatedCommandName) =>
+            $"_{char.ToLower(generatedCommandName[0], CultureInfo.InvariantCulture)}{generatedCommandName.Substring(1)}";
     }
 }

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -110,7 +110,8 @@ public partial class ReactiveCommandGenerator
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ReactiveCommandGenerator).FullName))),
                             AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ReactiveCommandGenerator).Assembly.GetName().Version.ToString())))))))
                         .AddModifiers(
-                        Token(SyntaxKind.PrivateKeyword));
+                        Token(SyntaxKind.PrivateKeyword))
+                        .NormalizeWhitespace();
 
             var commandDeclaration = PropertyDeclaration(
                 qualifiedName,

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.cs
@@ -139,10 +139,10 @@ public sealed partial class ReactiveCommandGenerator : IIncrementalGenerator
             // Generate all member declarations for the current type
             var propertyDeclarations =
                 commandInfos
-                .Select(Execute.GetCommandProperty)
+                .SelectMany(Execute.GetCommandProperty)
                 .ToList();
 
-            var c = Execute.GetCommandInitiliser(commandInfos);
+            var c = Execute.GetCommandInitiliser();
             propertyDeclarations.Add(c);
             var memberDeclarations = propertyDeclarations.ToImmutableArray();
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Declare command properties as notnull, fixes #46.


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Command properties are declared nullable.


**What is the new behavior?**
<!-- If this is a feature change -->
Command properties are declared as not null, `InitializeCommands` is obsoleted.


**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

This is my first ever contribution to a source generator. While everything seems to work, the current syntax is as follows:
```csharp
public ReactiveUI.ReactiveCommand<global::System.Reactive.Unit, global::System.Reactive.Unit> Test9AsyncCommand
{
    get
    {
        return _test9AsyncCommand ??= ReactiveUI.ReactiveCommand.CreateFromTask(Test9Async) ;;
    }
}
```

I was expecting arrow syntax since my latest modifications, but either the generated file isn't regenerated or my implementation is wrong.