### PR TITLE
Fix For CanExecute with IObservable<bool> Fields

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -18,6 +18,8 @@ namespace SGReactiveUI.SourceGenerators.Test;
 [DataContract]
 public partial class TestViewModel : ReactiveObject
 {
+    private readonly IObservable<bool> _observable = Observable.Return(true);
+
     [JsonInclude]
     [DataMember]
     [ObservableAsProperty]
@@ -67,6 +69,7 @@ public partial class TestViewModel : ReactiveObject
         cancel?.Dispose();
 
         Test10AsyncCommand?.Execute(200).Subscribe(r => Console.Out.WriteLine(r));
+        TestPrivateCanExecuteCommand?.Execute().Subscribe();
 
         Console.ReadLine();
     }
@@ -171,4 +174,7 @@ public partial class TestViewModel : ReactiveObject
 
     [ReactiveCommand]
     private async Task<Point> Test10Async(int size, CancellationToken ct) => await Task.FromResult(new Point(size, size));
+
+    [ReactiveCommand(CanExecute = nameof(_observable))]
+    private void TestPrivateCanExecute() => Console.Out.WriteLine("TestPrivateCanExecute");
 }

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/Models/CanExecuteTypeInfo.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/Models/CanExecuteTypeInfo.cs
@@ -8,5 +8,6 @@ namespace ReactiveUI.SourceGenerators.Input.Models;
 internal enum CanExecuteTypeInfo
 {
     PropertyObservable,
-    MethodObservable
+    MethodObservable,
+    FieldObservable,
 }

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -316,6 +316,18 @@ public partial class ReactiveCommandGenerator
 
                 return true;
             }
+            else if (canExecuteSymbol is IFieldSymbol canExecuteFieldSymbol)
+            {
+                // The property type must always be a bool
+                if (!IsObservableBoolType(canExecuteFieldSymbol.Type))
+                {
+                    goto Failure;
+                }
+
+                canExecuteTypeInfo = CanExecuteTypeInfo.FieldObservable;
+
+                return true;
+            }
 
         Failure:
             canExecuteTypeInfo = null;


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Closes #44

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

CanExecute ignored Fields

**What is the new behavior?**
<!-- If this is a feature change -->

CanExecute now generates correctly with fields.

**What might this PR break?**

None

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

