### PR TITLE
Fix Make IViewFor use Generic type

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ public partial class MyReactiveClass
 
 ### IViewFor usage
 
-IVIewFor is used to link a View to a ViewModel, this is used to link the ViewModel to the View in a way that ReactiveUI can use it to bind the ViewModel to the View.
-The ViewModel is passed as a string to the IViewFor Attribute.
+IViewFor is used to link a View to a ViewModel, this is used to link the ViewModel to the View in a way that ReactiveUI can use it to bind the ViewModel to the View.
+The ViewModel is passed as a type to the IViewFor Attribute using generics.
 The class must inherit from a UI Control from any of the following platforms and namespaces:
 - Maui (Microsoft.Maui)
 - WinUI (Microsoft.UI.Xaml)
@@ -317,7 +317,7 @@ The class must inherit from a UI Control from any of the following platforms and
 ```csharp
 using ReactiveUI.SourceGenerators;
 
-[IViewFor(nameof(MyReactiveClass))]
+[IViewFor<MyReactiveClass>]
 public partial class MyReactiveControl : UserControl
 {
     public MyReactiveControl()

--- a/src/ReactiveUI.SourceGenerators.Execute.Maui/IViewForTest.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Maui/IViewForTest.cs
@@ -11,6 +11,6 @@ namespace SGReactiveUI.SourceGenerators.Test.Maui
     /// IViewForTest.
     /// </summary>
     /// <seealso cref="NavigationPage" />
-    [IViewFor(nameof(TestViewModel))]
+    [IViewFor<TestViewModel>]
     public partial class IViewForTest : Shell;
 }

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWinForms.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWinForms.cs
@@ -11,7 +11,7 @@ namespace SGReactiveUI.SourceGenerators.Test
     /// TestViewWinForms.
     /// </summary>
     /// <seealso cref="System.Windows.Forms.Form" />
-    [IViewFor(nameof(TestViewModel))]
+    [IViewFor<TestViewModel>]
     public partial class TestViewWinForms : Form
     {
         /// <summary>

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf.cs
@@ -12,7 +12,7 @@ namespace SGReactiveUI.SourceGenerators.Test;
 /// <summary>
 /// TestView.
 /// </summary>
-[IViewFor(nameof(TestViewModel))]
+[IViewFor<TestViewModel>]
 public partial class TestViewWpf : Window
 {
     /// <summary>

--- a/src/ReactiveUI.SourceGenerators/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators/Core/Extensions/ITypeSymbolExtensions.cs
@@ -208,7 +208,7 @@ internal static class ITypeSymbolExtensions
 
         symbol.AppendFullyQualifiedMetadataName(builder);
 
-        return builder.WrittenSpan.SequenceEqual(name.AsSpan());
+        return builder.WrittenSpan.StartsWith(name.AsSpan());
     }
 
     public static bool ContainsFullyQualifiedMetadataName(this ITypeSymbol symbol, string name)

--- a/src/ReactiveUI.SourceGenerators/Core/Helpers/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators/Core/Helpers/AttributeDefinitions.cs
@@ -153,7 +153,7 @@ namespace ReactiveUI.SourceGenerators;
 /// <param name="viewModelType">Type of the view model.</param>
 [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.IViewForGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-internal sealed class IViewForAttribute(string? viewModelType) : Attribute;
+internal sealed class IViewForAttribute<T> : Attribute;
 #nullable restore
 #pragma warning restore
 """;

--- a/src/ReactiveUI.SourceGenerators/ReactiveUI.SourceGenerators.csproj
+++ b/src/ReactiveUI.SourceGenerators/ReactiveUI.SourceGenerators.csproj
@@ -41,6 +41,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
+  <ItemGroup>
+    <None Remove="bin\Debug\netstandard2.0\\ReactiveUI.SourceGenerators.dll" />
+  </ItemGroup>
 
   <!-- This ensures the library will be packaged as a source generator when we use `dotnet pack` -->
   <ItemGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Closes #54 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

IViewFor takes a string as a parameter

**What is the new behavior?**
<!-- If this is a feature change -->

IViewFor takes a Generic Type as a parameter

**What might this PR break?**

This is a breaking change update to use Generic type

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

