### PR TITLE
Fix For OAPH null values when set null after initial value

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ public partial class MyReactiveClass : ReactiveObject
 
 ## Usage ObservableAsPropertyHelper `[ObservableAsProperty]`
 
+ObservableAsPropertyHelper is used to create a read-only property from an IObservable. The generated code will create a backing field and a property that returns the value of the backing field. The backing field is initialized with the value of the IObservable when the class is instantiated.
+
+A private field is created with the name of the property prefixed with an underscore. The field is initialized with the value of the IObservable when the class is instantiated. The property is created with the same name as the field without the underscore. The property returns the value of the field until initialized, then it returns the value of the IObservable.
+
+You can define the name of the property by using the PropertyName parameter. If you do not define the PropertyName, the property name will be the same as the field name without the underscore.
+
 ### Usage ObservableAsPropertyHelper with Field
 ```csharp
 using ReactiveUI.SourceGenerators;
@@ -112,7 +118,10 @@ using ReactiveUI.SourceGenerators;
 public partial class MyReactiveClass : ReactiveObject
 {    
     public MyReactiveClass()
-    { 
+    {
+        // default value for MyObservableProperty prior to initialization.
+        _myObservable = "Test Value Pre Init";
+
         // Initialize generated _myObservablePropertyHelper
         // for the generated MyObservableProperty
         InitializeOAPH();
@@ -130,7 +139,10 @@ using ReactiveUI.SourceGenerators;
 public partial class MyReactiveClass : ReactiveObject
 {    
     public MyReactiveClass()
-    { 
+    {
+        // default value for TestValueProperty prior to initialization.
+        _testValueProperty = "Test Value Pre Init";
+
         // Initialize generated _testValuePropertyHelper
         // for the generated TestValueProperty
         InitializeOAPH();
@@ -143,7 +155,7 @@ public partial class MyReactiveClass : ReactiveObject
 
 ### Usage ObservableAsPropertyHelper with Observable Method
 
-NOTE: This does not support methods with parameters
+NOTE: This does not currently support methods with parameters
 ```csharp
 using ReactiveUI.SourceGenerators;
 

--- a/src/ReactiveUI.SourceGenerators/ObservableAsProperty/ObservableAsPropertyFromObservableGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ObservableAsProperty/ObservableAsPropertyFromObservableGenerator.Execute.cs
@@ -29,7 +29,18 @@ public partial class ObservableAsPropertyFromObservableGenerator
         {
             var getterFieldIdentifierName = GetGeneratedFieldName(propertyInfo);
 
-            var getterArrowExpression = ArrowExpressionClause(ParseExpression($"{getterFieldIdentifierName}Helper?.Value ?? default"));
+            // Get the property type syntax
+            TypeSyntax propertyType = IdentifierName(propertyInfo.GetObservableTypeText());
+
+            ArrowExpressionClauseSyntax getterArrowExpression;
+            if (propertyType.ToFullString().EndsWith("?"))
+            {
+                getterArrowExpression = ArrowExpressionClause(ParseExpression($"{getterFieldIdentifierName} = ({getterFieldIdentifierName}Helper == null ? {getterFieldIdentifierName} : {getterFieldIdentifierName}Helper.Value)"));
+            }
+            else
+            {
+                getterArrowExpression = ArrowExpressionClause(ParseExpression($"{getterFieldIdentifierName} = {getterFieldIdentifierName}Helper?.Value ?? {getterFieldIdentifierName}"));
+            }
 
             // Prepare the forwarded attributes, if any
             var forwardedAttributes =
@@ -37,35 +48,44 @@ public partial class ObservableAsPropertyFromObservableGenerator
                 .Select(static a => AttributeList(SingletonSeparatedList(a.GetSyntax())))
                 .ToImmutableArray();
 
-            // Get the property type syntax
-            TypeSyntax propertyType = IdentifierName(propertyInfo.GetObservableTypeText());
             return ImmutableArray.Create<MemberDeclarationSyntax>(
-                    FieldDeclaration(VariableDeclaration(ParseTypeName($"ReactiveUI.ObservableAsPropertyHelper<{propertyType}>?")))
-                .AddDeclarationVariables(VariableDeclarator(getterFieldIdentifierName + "Helper"))
-                .AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
-                        .AddArgumentListArguments(
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).FullName))),
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).Assembly.GetName().Version.ToString()))))))
-                    .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName + "Helper"}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())))
-                    .AddModifiers(
-                        Token(SyntaxKind.PrivateKeyword)),
-                    PropertyDeclaration(propertyType, Identifier(propertyInfo.PropertyName))
-                .AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
-                        .AddArgumentListArguments(
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).FullName))),
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).Assembly.GetName().Version.ToString()))))))
-                    .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
-                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName(AttributeDefinitions.ExcludeFromCodeCoverage)))))
-                .AddAttributeLists([.. forwardedAttributes])
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                    .WithExpressionBody(getterArrowExpression)
-                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))));
+                FieldDeclaration(VariableDeclaration(propertyType))
+                        .AddDeclarationVariables(VariableDeclarator(getterFieldIdentifierName))
+                        .AddAttributeLists(
+                            AttributeList(SingletonSeparatedList(
+                                Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
+                                .AddArgumentListArguments(
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).FullName))),
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).Assembly.GetName().Version.ToString()))))))
+                            .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{propertyInfo.PropertyName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())))
+                            .AddModifiers(
+                                Token(SyntaxKind.PrivateKeyword)),
+                FieldDeclaration(VariableDeclaration(ParseTypeName($"ReactiveUI.ObservableAsPropertyHelper<{propertyType}>?")))
+                    .AddDeclarationVariables(VariableDeclarator(getterFieldIdentifierName + "Helper"))
+                    .AddAttributeLists(
+                        AttributeList(SingletonSeparatedList(
+                            Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
+                            .AddArgumentListArguments(
+                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).FullName))),
+                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).Assembly.GetName().Version.ToString()))))))
+                        .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName + "Helper"}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())))
+                        .AddModifiers(
+                            Token(SyntaxKind.PrivateKeyword)),
+                PropertyDeclaration(propertyType, Identifier(propertyInfo.PropertyName))
+                    .AddAttributeLists(
+                        AttributeList(SingletonSeparatedList(
+                            Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
+                            .AddArgumentListArguments(
+                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).FullName))),
+                                AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyFromObservableGenerator).Assembly.GetName().Version.ToString()))))))
+                        .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
+                        AttributeList(SingletonSeparatedList(Attribute(IdentifierName(AttributeDefinitions.ExcludeFromCodeCoverage)))))
+                    .AddAttributeLists([.. forwardedAttributes])
+                    .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                    .AddAccessorListAccessors(
+                        AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                        .WithExpressionBody(getterArrowExpression)
+                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))));
         }
 
         internal static MethodDeclarationSyntax GetPropertyInitiliser(ObservableMethodInfo[] propertyInfos)

--- a/src/ReactiveUI.SourceGenerators/ObservableAsProperty/ObservableAsPropertyGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ObservableAsProperty/ObservableAsPropertyGenerator.Execute.cs
@@ -62,7 +62,16 @@ public partial class ObservableAsPropertyGenerator
                 getterFieldIdentifierName = propertyInfo.FieldName;
             }
 
-            var getterArrowExpression = ArrowExpressionClause(ParseExpression($"{getterFieldIdentifierName} = ({getterFieldIdentifierName}Helper?.Value ?? {getterFieldIdentifierName})"));
+            ArrowExpressionClauseSyntax getterArrowExpression;
+
+            if (propertyInfo.TypeNameWithNullabilityAnnotations.EndsWith("?"))
+            {
+                getterArrowExpression = ArrowExpressionClause(ParseExpression($"{getterFieldIdentifierName} = ({getterFieldIdentifierName}Helper == null ? {getterFieldIdentifierName} : {getterFieldIdentifierName}Helper.Value)"));
+            }
+            else
+            {
+                getterArrowExpression = ArrowExpressionClause(ParseExpression($"{getterFieldIdentifierName} = {getterFieldIdentifierName}Helper?.Value ?? {getterFieldIdentifierName}"));
+            }
 
             // Prepare the forwarded attributes, if any
             var forwardedAttributes =
@@ -83,32 +92,32 @@ public partial class ObservableAsPropertyGenerator
             return
                 ImmutableArray.Create<MemberDeclarationSyntax>(
                     FieldDeclaration(VariableDeclaration(ParseTypeName($"ReactiveUI.ObservableAsPropertyHelper<{propertyType}>")))
-                .AddDeclarationVariables(VariableDeclarator(getterFieldIdentifierName + "Helper"))
-                .AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
-                        .AddArgumentListArguments(
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).FullName))),
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).Assembly.GetName().Version.ToString()))))))
-                    .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{propertyInfo.FieldName + "Helper"}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())))
-                    .AddModifiers(
-                        Token(SyntaxKind.PrivateKeyword),
-                        Token(SyntaxKind.ReadOnlyKeyword)),
+                        .AddDeclarationVariables(VariableDeclarator(getterFieldIdentifierName + "Helper"))
+                        .AddAttributeLists(
+                            AttributeList(SingletonSeparatedList(
+                                Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
+                                .AddArgumentListArguments(
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).FullName))),
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).Assembly.GetName().Version.ToString()))))))
+                            .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{propertyInfo.FieldName + "Helper"}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())))
+                            .AddModifiers(
+                                Token(SyntaxKind.PrivateKeyword),
+                                Token(SyntaxKind.ReadOnlyKeyword)),
                     PropertyDeclaration(propertyType, Identifier(propertyInfo.PropertyName))
-                .AddAttributeLists(
-                    AttributeList(SingletonSeparatedList(
-                        Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
-                        .AddArgumentListArguments(
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).FullName))),
-                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).Assembly.GetName().Version.ToString()))))))
-                    .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
-                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName(AttributeDefinitions.ExcludeFromCodeCoverage)))))
-                .AddAttributeLists([.. forwardedAttributes])
-                .AddModifiers(Token(SyntaxKind.PublicKeyword))
-                .AddAccessorListAccessors(
-                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
-                    .WithExpressionBody(getterArrowExpression)
-                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))));
+                        .AddAttributeLists(
+                            AttributeList(SingletonSeparatedList(
+                                Attribute(IdentifierName(AttributeDefinitions.GeneratedCode))
+                                .AddArgumentListArguments(
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).FullName))),
+                                    AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ObservableAsPropertyGenerator).Assembly.GetName().Version.ToString()))))))
+                            .WithOpenBracketToken(Token(TriviaList(Comment($"/// <inheritdoc cref=\"{getterFieldIdentifierName}\"/>")), SyntaxKind.OpenBracketToken, TriviaList())),
+                            AttributeList(SingletonSeparatedList(Attribute(IdentifierName(AttributeDefinitions.ExcludeFromCodeCoverage)))))
+                        .AddAttributeLists([.. forwardedAttributes])
+                        .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                        .AddAccessorListAccessors(
+                            AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                            .WithExpressionBody(getterArrowExpression)
+                            .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))));
         }
 
         internal static bool GetFieldInfoFromClass(


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix
Closes #63

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

OAPH values using nullable types and a default value will revert to the default value if the Observable results in a null value

**What is the new behavior?**
<!-- If this is a feature change -->

Fix For OAPH null values when set null after initial value now allows null values to be propagated upon a null value being set from the connected Observable. 

**What might this PR break?**

Where previously the default value would have been return now the correct value will be returned.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

