### PR TITLE
Fix to disable RXUISG0016 analyzer for read-only properties

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -142,13 +142,47 @@ public partial class TestViewModel : ReactiveObject, IDisposable
     public static TestViewModel Instance { get; } = new();
 
     /// <summary>
-    /// Gets or sets the test property.
+    /// Gets the internal test property. Should not prompt to replace with INPC Reactive Property.
     /// </summary>
     /// <value>
     /// The test property.
     /// </value>
     [JsonInclude]
-    public string? TestProperty { get; set; } = "Test";
+    public string? TestInternalSetProperty { get; internal set; } = "Test";
+
+    /// <summary>
+    /// Gets the test private set property. Should not prompt to replace with INPC Reactive Property.
+    /// </summary>
+    /// <value>
+    /// The test private set property.
+    /// </value>
+    [JsonInclude]
+    public string? TestPrivateSetProperty { get; private set; } = "Test";
+
+    /// <summary>
+    /// Gets or sets the test automatic property.
+    /// </summary>
+    /// <value>
+    /// The test automatic property.
+    /// </value>
+    [JsonInclude]
+    public string? TestAutoProperty { get; set; } = "Test, should prompt to replace with INPC Reactive Property";
+
+    /// <summary>
+    /// Gets or sets the reactive command test property. Should not prompt to replace with INPC Reactive Property.
+    /// </summary>
+    /// <value>
+    /// The reactive command test property.
+    /// </value>
+    public ReactiveCommand<Unit, Unit>? ReactiveCommandTestProperty { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reactive property test property. Should not prompt to replace with INPC Reactive Property.
+    /// </summary>
+    /// <value>
+    /// The reactive property test property.
+    /// </value>
+    public ReactiveProperty<int>? ReactivePropertyTestProperty { get; set; }
 
     /// <summary>
     /// Gets the can execute test1.

--- a/src/ReactiveUI.SourceGenerators/Diagnostics/CodeAnalyzers/PropertyToReactiveFieldAnalyzer.cs
+++ b/src/ReactiveUI.SourceGenerators/Diagnostics/CodeAnalyzers/PropertyToReactiveFieldAnalyzer.cs
@@ -52,8 +52,12 @@ namespace ReactiveUI.SourceGenerators.CodeAnalyzers
             }
 
             var isAutoProperty = propertyDeclaration.ExpressionBody == null && (propertyDeclaration.AccessorList?.Accessors.All(a => a.Body == null && a.ExpressionBody == null) != false);
+            var hasCorrectModifiers = propertyDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword) && !propertyDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword);
+            var doesNotHavePrivateSetOrInternalSet = propertyDeclaration.AccessorList?.Accessors.Any(a => a.Modifiers.Any(SyntaxKind.PrivateKeyword) || a.Modifiers.Any(SyntaxKind.InternalKeyword)) == false;
+            var isNotReactiveCommand = !propertyDeclaration.Type.ToString().Contains("ReactiveCommand");
+            var isNotReactiveProperty = !propertyDeclaration.Type.ToString().Contains("ReactiveProperty");
 
-            if (isAutoProperty && propertyDeclaration.Modifiers.Any(SyntaxKind.PublicKeyword) && !propertyDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword))
+            if (isAutoProperty && hasCorrectModifiers && doesNotHavePrivateSetOrInternalSet && isNotReactiveCommand && isNotReactiveProperty)
             {
                 var diagnostic = Diagnostic.Create(DiagnosticDescriptors.PropertyToReactiveFieldRule, propertyDeclaration.GetLocation());
                 context.ReportDiagnostic(diagnostic);


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix
Closes #66

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

RXUISG0016 analyzer does not have sufficient filters to ensure only public Auto properties without private or internal setters are recommended for conversion to [Reactive] properties.

**What is the new behavior?**
<!-- If this is a feature change -->

Fix to disable RXUISG0016 analyzer for read-only properties
Add filters for ReactiveProperty and ReactiveCommand to ensure they are not flagged for conversion

**What might this PR break?**

None, less properties will be flagged for possible conversion.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

