### PR TITLE
Feature - Update to Strip Async suffix from Generated Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,9 @@ using ReactiveUI.SourceGenerators;
 public partial class MyReactiveClass
 {
     [ReactiveCommand]
-    private async Task<string> Execute(string parameter) => await Task.FromResult(parameter);
+    private async Task<string> ExecuteAsync(string parameter) => await Task.FromResult(parameter);
+
+    // Generates the following code ExecuteCommand, Note the Async suffix is removed
 }
 ```
 

--- a/src/ReactiveUI.SourceGenerators.Execute.Maui/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Maui/TestViewModel.cs
@@ -35,18 +35,18 @@ public partial class TestViewModel : ReactiveObject
     {
         Console.Out.WriteLine(Test1Command);
         Console.Out.WriteLine(Test2Command);
-        Console.Out.WriteLine(Test3AsyncCommand);
-        Console.Out.WriteLine(Test4AsyncCommand);
+        Console.Out.WriteLine(Test3Command);
+        Console.Out.WriteLine(Test4Command);
         Console.Out.WriteLine(Test5StringToIntCommand);
         Console.Out.WriteLine(Test6ArgOnlyCommand);
         Console.Out.WriteLine(Test7ObservableCommand);
         Console.Out.WriteLine(Test8ObservableCommand);
-        Console.Out.WriteLine(Test9AsyncCommand);
-        Console.Out.WriteLine(Test10AsyncCommand);
+        Console.Out.WriteLine(Test9Command);
+        Console.Out.WriteLine(Test10Command);
         Test1Command?.Execute().Subscribe();
         Test2Command?.Execute().Subscribe(r => Console.Out.WriteLine(r));
-        Test3AsyncCommand?.Execute().Subscribe();
-        Test4AsyncCommand?.Execute().Subscribe(r => Console.Out.WriteLine(r));
+        Test3Command?.Execute().Subscribe();
+        Test4Command?.Execute().Subscribe(r => Console.Out.WriteLine(r));
         Test5StringToIntCommand?.Execute("100").Subscribe(Console.Out.WriteLine);
         Test6ArgOnlyCommand?.Execute("Hello World").Subscribe();
         Test7ObservableCommand?.Execute().Subscribe();
@@ -57,12 +57,12 @@ public partial class TestViewModel : ReactiveObject
         Console.Out.WriteLine($"Test2Property Value: {Test2}");
         Console.Out.WriteLine($"Test2Property underlying Value: {_test2Property}");
 
-        Test9AsyncCommand?.ThrownExceptions.Subscribe(Console.Out.WriteLine);
-        var cancel = Test9AsyncCommand?.Execute().Subscribe();
+        Test9Command?.ThrownExceptions.Subscribe(Console.Out.WriteLine);
+        var cancel = Test9Command?.Execute().Subscribe();
         Task.Delay(1000).Wait();
         cancel?.Dispose();
 
-        Test10AsyncCommand?.Execute(200).Subscribe(r => Console.Out.WriteLine(r));
+        Test10Command?.Execute(200).Subscribe(r => Console.Out.WriteLine(r));
     }
 
     /// <summary>

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -60,18 +60,18 @@ public partial class TestViewModel : ReactiveObject, IDisposable
 
         Console.Out.WriteLine(Test1Command);
         Console.Out.WriteLine(Test2Command);
-        Console.Out.WriteLine(Test3AsyncCommand);
-        Console.Out.WriteLine(Test4AsyncCommand);
+        Console.Out.WriteLine(Test3Command);
+        Console.Out.WriteLine(Test4Command);
         Console.Out.WriteLine(Test5StringToIntCommand);
         Console.Out.WriteLine(Test6ArgOnlyCommand);
         Console.Out.WriteLine(Test7ObservableCommand);
         Console.Out.WriteLine(Test8ObservableCommand);
-        Console.Out.WriteLine(Test9AsyncCommand);
-        Console.Out.WriteLine(Test10AsyncCommand);
+        Console.Out.WriteLine(Test9Command);
+        Console.Out.WriteLine(Test10Command);
         Test1Command?.Execute().Subscribe();
         Test2Command?.Execute().Subscribe(r => Console.Out.WriteLine(r));
-        Test3AsyncCommand?.Execute().Subscribe();
-        Test4AsyncCommand?.Execute().Subscribe(r => Console.Out.WriteLine(r));
+        Test3Command?.Execute().Subscribe();
+        Test4Command?.Execute().Subscribe(r => Console.Out.WriteLine(r));
         Test5StringToIntCommand?.Execute("100").Subscribe(Console.Out.WriteLine);
         Test6ArgOnlyCommand?.Execute("Hello World").Subscribe();
         Test7ObservableCommand?.Execute().Subscribe();
@@ -122,12 +122,12 @@ public partial class TestViewModel : ReactiveObject, IDisposable
         Console.Out.WriteLine(MyReadOnlyNonNullProperty);
         Console.Out.WriteLine(_myReadOnlyNonNullProperty);
 
-        Test9AsyncCommand?.ThrownExceptions.Subscribe(Console.Out.WriteLine);
-        var cancel = Test9AsyncCommand?.Execute().Subscribe();
+        Test9Command?.ThrownExceptions.Subscribe(Console.Out.WriteLine);
+        var cancel = Test9Command?.Execute().Subscribe();
         Task.Delay(1000).Wait();
         cancel?.Dispose();
 
-        Test10AsyncCommand?.Execute(200).Subscribe(r => Console.Out.WriteLine(r));
+        Test10Command?.Execute(200).Subscribe(r => Console.Out.WriteLine(r));
         TestPrivateCanExecuteCommand?.Execute().Subscribe();
 
         Console.ReadLine();

--- a/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -57,7 +57,7 @@ public partial class ReactiveCommandGenerator
         {
             var outputType = commandExtensionInfo.GetOutputTypeText();
             var inputType = commandExtensionInfo.GetInputTypeText();
-            var commandName = GetGeneratedCommandName(commandExtensionInfo.MethodName);
+            var commandName = GetGeneratedCommandName(commandExtensionInfo.MethodName, commandExtensionInfo.IsTask);
             var fieldName = GetGeneratedFieldName(commandName);
 
             ExpressionSyntax initializer;
@@ -463,7 +463,7 @@ public partial class ReactiveCommandGenerator
             propertyAttributes = propertyAttributesInfo.ToImmutable();
         }
 
-        internal static string GetGeneratedCommandName(string methodName)
+        internal static string GetGeneratedCommandName(string methodName, bool isAsync)
         {
             var commandName = methodName;
 
@@ -474,6 +474,11 @@ public partial class ReactiveCommandGenerator
             else if (commandName.StartsWith("_"))
             {
                 commandName = commandName.TrimStart('_');
+            }
+
+            if (commandName.EndsWith("Async") && isAsync)
+            {
+                commandName = commandName.Substring(0, commandName.Length - "Async".Length);
             }
 
             return $"{char.ToUpper(commandName[0], CultureInfo.InvariantCulture)}{commandName.Substring(1)}Command";


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update
Closes #78 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#78

**What is the new behavior?**
<!-- If this is a feature change -->

Methods that are Task's and have Async at the end of the Method name with have Async removed from the Command name.

**What might this PR break?**

Existing users will need to update their code to remove the Async part of the name

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

