### PR TITLE
Fix for OAPH can't be created outside of constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,24 +111,29 @@ public partial class MyReactiveClass : ReactiveObject
 }
 ```
 
+### Usage ObservableAsPropertyHelper with Field and non readonly nullable OAPH field
+```csharp
+
 ### Usage ObservableAsPropertyHelper with Observable Property
 ```csharp
 using ReactiveUI.SourceGenerators;
 
-public partial class MyReactiveClass : ReactiveObject
-{    
+public partial class MyReactiveClass : ReactiveObject, IActivatableViewModel
+{
+    [ObservableAsProperty(ReadOnly = false)]
+    private string _myProperty = "Default Value";
+
     public MyReactiveClass()
     {
-        // default value for MyObservableProperty prior to initialization.
-        _myObservable = "Test Value Pre Init";
-
-        // Initialize generated _myObservablePropertyHelper
-        // for the generated MyObservableProperty
-        InitializeOAPH();
+        this.WhenActivated(disposables =>
+        {
+            _myPrpertyHelper = MyPropertyObservable()
+                .ToProperty(this, x => x.MyProperty)
+                .DisposeWith(disposables);
+        });
     }
 
-    [ObservableAsProperty]
-    IObservable<string> MyObservable => Observable.Return("Test Value");
+    IObservable<string> MyPropertyObservable() => Observable.Return("Test Value");
 }
 ```
 

--- a/src/ReactiveUI.SourceGenerators/Core/Helpers/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators/Core/Helpers/AttributeDefinitions.cs
@@ -161,6 +161,14 @@ internal sealed class ObservableAsPropertyAttribute : Attribute
     /// The name of the property.
     /// </value>
     public string? PropertyName { get; init; }
+
+    /// <summary>
+    /// Gets the Readonly state of the OAPH property.
+    /// </summary>
+    /// <value>
+    /// The is read only of the OAPH property.
+    /// </value>
+    public bool ReadOnly { get; init; } = true;
 }
 #nullable restore
 #pragma warning restore


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature
closes #75 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#75

**What is the new behavior?**
<!-- If this is a feature change -->

OAPH attribute now has a ReadOnly property that if set false will remove the readonly declaration of OAPH fields

**What might this PR break?**

None expected as currently there is a restriction, and the new code introduces a new property.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

