### PR TITLE
Fix for Use string .ToProperty overload

### DIFF
--- a/src/ReactiveUI.SourceGenerators/ObservableAsProperty/ObservableAsPropertyFromObservableGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/ObservableAsProperty/ObservableAsPropertyFromObservableGenerator.Execute.cs
@@ -97,11 +97,11 @@ public partial class ObservableAsPropertyFromObservableGenerator
                 var fieldIdentifierName = GetGeneratedFieldName(propertyInfo);
                 if (propertyInfo.IsProperty)
                 {
-                    propertyInitilisers.Add(ParseStatement($"{fieldIdentifierName}Helper = {propertyInfo.MethodName}!.ToProperty(this, x => x.{propertyInfo.PropertyName});"));
+                    propertyInitilisers.Add(ParseStatement($"{fieldIdentifierName}Helper = {propertyInfo.MethodName}!.ToProperty(this, nameof({propertyInfo.PropertyName}));"));
                 }
                 else
                 {
-                    propertyInitilisers.Add(ParseStatement($"{fieldIdentifierName}Helper = {propertyInfo.MethodName}()!.ToProperty(this, x => x.{propertyInfo.PropertyName});"));
+                    propertyInitilisers.Add(ParseStatement($"{fieldIdentifierName}Helper = {propertyInfo.MethodName}()!.ToProperty(this, nameof({propertyInfo.PropertyName}));"));
                 }
             }
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix
closes #72 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#72

**What is the new behavior?**
<!-- If this is a feature change -->

The code has been updated to use nameof(Property) where this is generated

**What might this PR break?**

none, a performance increase may be present

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

