### PR TITLE
Add unit tests for verify

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -43,6 +43,24 @@ dotnet_diagnostic.CA2009.severity=error
 dotnet_diagnostic.CA2008.severity=error
 dotnet_diagnostic.CA2007.severity=warning
 dotnet_diagnostic.CA2000.severity=suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+end_of_line = lf
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 
 [project.json]
 indent_size = 2
@@ -87,7 +105,7 @@ dotnet_style_predefined_type_for_member_access = true:suggestion
 # name all constant fields using PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds   = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
@@ -95,7 +113,7 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 # static fields should have s_ prefix
 dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
 dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
@@ -105,7 +123,7 @@ dotnet_naming_style.static_prefix_style.capitalization = camel_case
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
@@ -501,6 +519,11 @@ dotnet_diagnostic.RCS1180.severity=warning
 dotnet_diagnostic.RCS1190.severity=error
 dotnet_diagnostic.RCS1195.severity=error
 dotnet_diagnostic.RCS1214.severity=error
+csharp_style_namespace_declarations = file_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,16 +5,6 @@
     <CodeAnalysisVersion>4.0.1</CodeAnalysisVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
-    <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
-    <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <PackageVersion Include="stylecop.analyzers" Version="1.2.0-beta.556" />
@@ -36,5 +26,20 @@
 
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageVersion Include="ReactiveUI.Maui" Version="20.1.63" />
+
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Xunit.StaFact" Version="1.1.11" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
+    <PackageVersion Include="PublicApiGenerator" Version="11.1.0" />
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
+    <PackageVersion Include="Verify.Xunit" Version="26.6.0" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
+    <PackageVersion Include="ReactiveMarbles.SourceGenerator.TestNuGetHelper" Version="1.3.1" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80Windows" Version="1.7.9" />
   </ItemGroup>
 </Project>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -36,18 +36,6 @@
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  <ItemGroup Condition="$(IsTestProject)">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.console" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="Xunit.StaFact" />
-    <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="Microsoft.Reactive.Testing" />
-    <PackageReference Include="PublicApiGenerator" />
-    <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
-    <PackageReference Include="Verify.Xunit" />
-  </ItemGroup>
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>

--- a/src/ReactiveUI.SourceGenerator.Tests/ModuleInitializer.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/ModuleInitializer.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Initializes the source generator verifiers.
+/// </summary>
+public static class ModuleInitializer
+{
+    /// <summary>
+    /// Initializes the source generators.
+    /// </summary>
+    [ModuleInitializer]
+    public static void Init() => VerifySourceGenerators.Initialize();
+}

--- a/src/ReactiveUI.SourceGenerator.Tests/ObservableAsPropertyFromObservableGeneratorUnitTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/ObservableAsPropertyFromObservableGeneratorUnitTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ReactiveUI.SourceGenerators;
+
+using Xunit.Abstractions;
+
+namespace ReactiveUI.SourceGenerator.Tests;
+
+/// <summary>
+/// Unit tests for the ObservableAsProperty generator.
+/// </summary>
+/// <param name="output">The output helper.</param>
+public class ObservableAsPropertyFromObservableGeneratorUnitTests(ITestOutputHelper output) : TestBase(output)
+{
+    /// <summary>
+    /// Tests that the source generator correctly generates observable properties.
+    /// </summary>
+    /// <returns>A task to monitor the async.</returns>
+    [Fact]
+    public Task Generator_ShouldGenerate_ObservablePropertiesCorrectly()
+    {
+        // Arrange: Setup the source code that matches the generator input expectations.
+        var sourceCode = @"
+                using ReactiveUI;
+                using System.Reactive.Linq;
+
+                namespace TestNamespace
+                {
+                    public partial class TestViewModel : ReactiveObject
+                    {
+                        [ObservableAsProperty]
+                        public IObservable<int> MyProperty => Observable.Return(42);
+                    }
+                }
+            ";
+
+        // Act: Initialize the helper and run the generator.
+        var driver = TestHelper.TestPass<ObservableAsPropertyFromObservableGenerator>(
+            sourceCode,
+            "MyProperty",
+            typeof(ObservableAsPropertyFromObservableGenerator));
+
+        // Assert: Verify the generated code.
+        return Verify(driver);
+    }
+}

--- a/src/ReactiveUI.SourceGenerator.Tests/ReactiveUI.SourceGenerator.Tests.csproj
+++ b/src/ReactiveUI.SourceGenerator.Tests/ReactiveUI.SourceGenerator.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CA1812;CA1001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="ReactiveMarbles.SourceGenerator.TestNuGetHelper" />
+    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.SourceGenerators" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" VersionOverride="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" VersionOverride="4.11.0" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReactiveUI.SourceGenerators\ReactiveUI.SourceGenerators.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReactiveUI.SourceGenerator.Tests/TestBase.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/TestBase.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Xunit.Abstractions;
+
+namespace ReactiveUI.SourceGenerator.Tests;
+
+/// <summary>
+/// A base class for handling test setup and teardown.
+/// </summary>
+/// <param name="testOutputHelper">The output helper.</param>
+public abstract class TestBase(ITestOutputHelper testOutputHelper) : IAsyncLifetime, IDisposable
+{
+    /// <summary>
+    /// Gets the TestHelper instance.
+    /// </summary>
+    protected TestHelper TestHelper { get; } = new(testOutputHelper);
+
+    /// <inheritdoc/>
+    public Task InitializeAsync() => TestHelper.InitializeAsync();
+
+    /// <inheritdoc/>
+    public Task DisposeAsync()
+    {
+        TestHelper.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Disposes the resources used by the TestBase.
+    /// </summary>
+    /// <param name="isDisposing">True if called from Dispose method, false if called from finalizer.</param>
+    protected virtual void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            TestHelper.Dispose();
+        }
+    }
+}

--- a/src/ReactiveUI.SourceGenerator.Tests/TestHelper.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/TestHelper.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+using FluentAssertions;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Versioning;
+
+using ReactiveMarbles.NuGet.Helpers;
+
+using ReactiveMarbles.SourceGenerator.TestNuGetHelper.Compilation;
+
+using Xunit.Abstractions;
+
+namespace ReactiveUI.SourceGenerator.Tests;
+
+/// <summary>
+/// A helper class to facilitate the testing of incremental source generators.
+/// It provides utilities to initialize dependencies, run generators, and verify the output.
+/// </summary>
+/// <param name="testOutput">The test output helper for capturing test logs.</param>
+public sealed class TestHelper(ITestOutputHelper testOutput) : IDisposable
+{
+    /// <summary>
+    /// Represents the NuGet library dependency for the Splat library.
+    /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete
+    private static readonly LibraryRange SplatLibrary =
+        new("Splat", VersionRange.AllStableFloating, LibraryDependencyTarget.Package);
+
+    /// <summary>
+    /// Represents the NuGet library dependency for the ReactiveUI library.
+    /// </summary>
+    private static readonly LibraryRange ReactiveuiLibrary =
+        new("ReactiveUI", VersionRange.AllStableFloating, LibraryDependencyTarget.Package);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    /// <summary>
+    /// Holds the compiler instance used for event-related code generation.
+    /// </summary>
+    private EventBuilderCompiler? _eventCompiler;
+
+    /// <summary>
+    /// Asynchronously initializes the source generator helper by downloading required packages.
+    /// </summary>
+    /// <returns>A task representing the asynchronous initialization operation.</returns>
+    public async Task InitializeAsync()
+    {
+        NuGetFramework[] targetFrameworks = [new NuGetFramework(".NETCoreApp", new Version(8, 0, 0, 0))];
+
+        // Download necessary NuGet package files.
+        var inputGroup = await NuGetPackageHelper.DownloadPackageFilesAndFolder(
+            new[] { SplatLibrary, ReactiveuiLibrary },
+            targetFrameworks,
+            packageOutputDirectory: null).ConfigureAwait(false);
+
+        // Initialize the event compiler with downloaded packages and target framework.
+        var framework = targetFrameworks[0];
+        _eventCompiler = new EventBuilderCompiler(inputGroup, inputGroup, framework);
+    }
+
+    /// <summary>
+    /// Tests a generator expecting it to fail by throwing an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the incremental generator being tested.</typeparam>
+    /// <param name="source">The source code to test.</param>
+    /// <param name="contractParameter">The parameter to be used in the test.</param>
+    /// <param name="callerType">The type that called this test method.</param>
+    /// <param name="file">The path of the calling file (auto-populated).</param>
+    /// <param name="memberName">The name of the calling member (auto-populated).</param>
+    public void TestFail<T>(
+        string source,
+        string contractParameter,
+        Type callerType,
+        [CallerFilePath] string file = "",
+        [CallerMemberName] string memberName = "")
+        where T : IIncrementalGenerator, new()
+    {
+        if (callerType is null)
+        {
+            throw new ArgumentNullException(nameof(callerType));
+        }
+
+        if (_eventCompiler is null)
+        {
+            throw new InvalidOperationException("Must have valid compiler instance.");
+        }
+
+        var utility = new SourceGeneratorUtility(x => testOutput.WriteLine(x));
+
+        Assert.Throws<InvalidOperationException>(() => RunGeneratorAndCheck<T>(source));
+    }
+
+    /// <summary>
+    /// Tests a generator expecting it to pass successfully.
+    /// </summary>
+    /// <typeparam name="T">The type of the incremental generator being tested.</typeparam>
+    /// <param name="source">The source code to test.</param>
+    /// <param name="contractParameter">The parameter to be used in the test.</param>
+    /// <param name="callerType">The type that called this test method.</param>
+    /// <param name="file">The path of the calling file (auto-populated).</param>
+    /// <param name="memberName">The name of the calling member (auto-populated).</param>
+    /// <returns>The driver.</returns>
+    public GeneratorDriver TestPass<T>(
+        string source,
+        string contractParameter,
+        Type callerType,
+        [CallerFilePath] string file = "",
+        [CallerMemberName] string memberName = "")
+        where T : IIncrementalGenerator, new()
+    {
+        if (callerType is null)
+        {
+            throw new ArgumentNullException(nameof(callerType));
+        }
+
+        return RunGeneratorAndCheck<T>(source);
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _eventCompiler?.Dispose();
+
+    /// <summary>
+    /// Runs the specified source generator and validates the generated code.
+    /// </summary>
+    /// <typeparam name="T">The type of the source generator.</typeparam>
+    /// <param name="code">The code to be parsed and processed by the generator.</param>
+    /// <param name="ignoreConditional">Optional. A function to ignore specific diagnostics.</param>
+    /// <param name="rerunCompilation">Indicates whether to rerun the compilation after running the generator.</param>
+    /// <returns>The generator driver used to run the generator.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the compiler instance is not valid or if the compilation fails.
+    /// </exception>
+    public GeneratorDriver RunGeneratorAndCheck<T>(
+        string code,
+        Func<Diagnostic, bool>? ignoreConditional = null,
+        bool rerunCompilation = true)
+        where T : IIncrementalGenerator, new()
+    {
+        if (_eventCompiler is null)
+        {
+            throw new InvalidOperationException("Must have a valid compiler instance.");
+        }
+
+        // Collect required assembly references.
+        var assemblies = new HashSet<MetadataReference>(
+            Basic.Reference.Assemblies.Net80.References.All
+            .Concat(_eventCompiler.Modules.Select(x => MetadataReference.CreateFromFile(x.PEFile!.FileName)))
+            .Concat(_eventCompiler.ReferencedModules.Select(x => MetadataReference.CreateFromFile(x.PEFile!.FileName)))
+            .Concat(_eventCompiler.NeededModules.Select(x => MetadataReference.CreateFromFile(x.PEFile!.FileName))));
+
+        // Create a compilation with the provided source code.
+        var compilation = CSharpCompilation.Create(
+            "TestProject",
+            [CSharpSyntaxTree.ParseText(code)],
+            assemblies,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, deterministic: true));
+
+        // Optionally validate diagnostics before running the generator.
+        if (ignoreConditional is not null)
+        {
+            var diagnostics = compilation.GetDiagnostics().ToList();
+            diagnostics.Where(x => !ignoreConditional(x)).Should().BeEmpty();
+        }
+
+        var generator = new T();
+        var driver = CSharpGeneratorDriver.Create(generator.AsSourceGenerator());
+
+        if (rerunCompilation)
+        {
+            // Run the generator and capture diagnostics.
+            var rerunDriver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out var diagnostics);
+
+            // If any warnings or errors are found, log them to the test output before throwing an exception.
+            var offendingDiagnostics = diagnostics
+                .Where(d => d.Severity >= DiagnosticSeverity.Warning)
+                .ToList();
+
+            if (offendingDiagnostics.Count > 0)
+            {
+                foreach (var diagnostic in offendingDiagnostics)
+                {
+                    testOutput.WriteLine($"Diagnostic: {diagnostic.Id} - {diagnostic.GetMessage()}");
+                }
+
+                throw new InvalidOperationException("Compilation failed due to the above diagnostics.");
+            }
+
+            return rerunDriver;
+        }
+
+        // If rerun is not needed, simply run the generator.
+        return driver.RunGenerators(compilation);
+    }
+}

--- a/src/ReactiveUI.SourceGenerators.sln
+++ b/src/ReactiveUI.SourceGenerators.sln
@@ -6,12 +6,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionConfig", "SolutionC
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
 		..\.gitignore = ..\.gitignore
-		..\LICENSE = ..\LICENSE
-		..\README.md = ..\README.md
-		..\version.json = ..\version.json
 		Directory.build.props = Directory.build.props
 		Directory.Packages.props = Directory.Packages.props
+		..\LICENSE = ..\LICENSE
+		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
+		..\version.json = ..\version.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.SourceGenerators.Execute", "ReactiveUI.SourceGenerators.Execute\ReactiveUI.SourceGenerators.Execute.csproj", "{76D5AC8C-4935-3E4B-BD12-71FAEC2B9A9D}"
@@ -19,6 +19,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.SourceGenerators", "ReactiveUI.SourceGenerators\ReactiveUI.SourceGenerators.csproj", "{A8CE4CD8-F858-67F2-E50D-86C5C17C6BE6}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.SourceGenerators.Execute.Maui", "ReactiveUI.SourceGenerators.Execute.Maui\ReactiveUI.SourceGenerators.Execute.Maui.csproj", "{849CACF4-B85F-47B5-84B3-7C94DE864E7E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.SourceGenerator.Tests", "ReactiveUI.SourceGenerator.Tests\ReactiveUI.SourceGenerator.Tests.csproj", "{60C7C031-8765-46D7-8E0D-88CD4949F25B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,16 +32,23 @@ Global
 		{76D5AC8C-4935-3E4B-BD12-71FAEC2B9A9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76D5AC8C-4935-3E4B-BD12-71FAEC2B9A9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76D5AC8C-4935-3E4B-BD12-71FAEC2B9A9D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A8CE4CD8-F858-67F2-E50D-86C5C17C6BE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A8CE4CD8-F858-67F2-E50D-86C5C17C6BE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A8CE4CD8-F858-67F2-E50D-86C5C17C6BE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8CE4CD8-F858-67F2-E50D-86C5C17C6BE6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{849CACF4-B85F-47B5-84B3-7C94DE864E7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60C7C031-8765-46D7-8E0D-88CD4949F25B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60C7C031-8765-46D7-8E0D-88CD4949F25B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60C7C031-8765-46D7-8E0D-88CD4949F25B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60C7C031-8765-46D7-8E0D-88CD4949F25B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {173F891B-86A2-4226-B563-A7318CE0E2EC}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Adding some basic verify unit tests to confirm when we are making changes that the changes are expected.

Adding to make it easier to convert to more cache friendly/performant incremental generators to make sure the end output is still the same.