### PR TITLE
Update tests to remove generator version before verifying

### DIFF
--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test2Property"/>
         private int _test2Property;
 
@@ -23,7 +23,7 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2Property { get => _test2Property = _test2PropertyHelper?.Value ?? _test2Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test2Property"/>
         private int _test2Property;
 
@@ -23,7 +22,6 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2Property { get => _test2Property = _test2PropertyHelper?.Value ?? _test2Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test3Property"/>
         private int _test3Property;
 
@@ -23,7 +23,7 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test3Property { get => _test3Property = _test3PropertyHelper?.Value ?? _test3Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test3Property"/>
         private int _test3Property;
 
@@ -23,7 +22,6 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test3Property { get => _test3Property = _test3PropertyHelper?.Value ?? _test3Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test1Property"/>
         private int _test1Property;
 
@@ -23,7 +23,7 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1Property { get => _test1Property = _test1PropertyHelper?.Value ?? _test1Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test1Property"/>
         private int _test1Property;
 
@@ -23,7 +22,6 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1Property { get => _test1Property = _test1PropertyHelper?.Value ?? _test1Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test5Property"/>
         private int _test5Property;
 
@@ -24,7 +23,6 @@ namespace TestNs
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]
         public int Test5Property { get => _test5Property = _test5PropertyHelper?.Value ?? _test5Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test5Property"/>
         private int _test5Property;
 
@@ -24,7 +24,7 @@ namespace TestNs
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]
         public int Test5Property { get => _test5Property = _test5PropertyHelper?.Value ?? _test5Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test4Property"/>
         private int _test4Property;
 
@@ -23,7 +22,6 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test4Property { get => _test4Property = _test4PropertyHelper?.Value ?? _test4Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="Test4Property"/>
         private int _test4Property;
 
@@ -23,7 +23,7 @@ namespace TestNs
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test4Property { get => _test4Property = _test4PropertyHelper?.Value ?? _test4Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#TestVM.ObservableAsProperties.g.verified.cs
@@ -7,7 +7,7 @@ namespace TestNs
     /// <inheritdoc/>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test1Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test1Helper;
 

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#TestVM.ObservableAsProperties.g.verified.cs
@@ -7,7 +7,6 @@ namespace TestNs
     /// <inheritdoc/>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test1Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test1Helper;
 

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#TestVM.ObservableAsProperties.g.verified.cs
@@ -7,7 +7,6 @@ namespace TestNs
     /// <inheritdoc/>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test2Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test2Helper;
 

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#TestVM.ObservableAsProperties.g.verified.cs
@@ -7,7 +7,7 @@ namespace TestNs
     /// <inheritdoc/>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test2Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test2Helper;
 

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ObservableAsPropertyAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ObservableAsPropertyAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#TestVM.ObservableAsProperties.g.verified.cs
@@ -7,7 +7,6 @@ namespace TestNs
     /// <inheritdoc/>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test2Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test2Helper;
 

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#TestVM.ObservableAsProperties.g.verified.cs
@@ -7,7 +7,7 @@ namespace TestNs
     /// <inheritdoc/>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test2Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test2Helper;
 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "1.1.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#TestVM.Properties.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test3"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#TestVM.Properties.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test3"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "1.1.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#TestVM.Properties.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test1"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#TestVM.Properties.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test1"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -15,7 +15,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "1.1.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#TestVM.Properties.g.verified.cs
@@ -12,7 +12,6 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test2"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#TestVM.Properties.g.verified.cs
@@ -12,7 +12,7 @@ namespace TestNs
     /// </summary>
     public partial class TestVM
     {
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "1.1.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.0.0.0")]
         /// <inheritdoc cref="_test2"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReativeCommandAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveCommandGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveCommandAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReativeCommandAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveCommandGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveCommandAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReativeCommandAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveCommandGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveCommandAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -15,7 +15,6 @@ namespace ReactiveUI.SourceGenerators;
 /// ReativeCommandAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveCommandGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveCommandAttribute : Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPFromObservableGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPFromObservableGeneratorTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
 using ReactiveUI.SourceGenerators;
 using Xunit.Abstractions;
 
@@ -41,7 +42,7 @@ public class OAPFromObservableGeneratorTests(ITestOutputHelper output) : TestBas
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -71,7 +72,7 @@ public class OAPFromObservableGeneratorTests(ITestOutputHelper output) : TestBas
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -101,7 +102,7 @@ public class OAPFromObservableGeneratorTests(ITestOutputHelper output) : TestBas
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -131,7 +132,7 @@ public class OAPFromObservableGeneratorTests(ITestOutputHelper output) : TestBas
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -165,6 +166,8 @@ public class OAPFromObservableGeneratorTests(ITestOutputHelper output) : TestBas
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
+
+    private SettingsTask VerifyGenerator(GeneratorDriver driver) => Verify(driver).UseDirectory(TestHelper.VerifiedFilePath()).ScrubLinesContaining("[global::System.CodeDom.Compiler.GeneratedCode(\"");
 }

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPGeneratorTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
 using ReactiveUI.SourceGenerators;
 using Xunit.Abstractions;
 
@@ -41,7 +42,7 @@ public class OAPGeneratorTests(ITestOutputHelper output) : TestBase<ObservableAs
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -71,7 +72,7 @@ public class OAPGeneratorTests(ITestOutputHelper output) : TestBase<ObservableAs
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -101,6 +102,8 @@ public class OAPGeneratorTests(ITestOutputHelper output) : TestBase<ObservableAs
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
+
+    private SettingsTask VerifyGenerator(GeneratorDriver driver) => Verify(driver).UseDirectory(TestHelper.VerifiedFilePath()).ScrubLinesContaining("[global::System.CodeDom.Compiler.GeneratedCode(\"");
 }

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
 using ReactiveUI.SourceGenerators;
 using Xunit.Abstractions;
 
@@ -42,7 +43,7 @@ public class ReactiveCMDGeneratorTests(ITestOutputHelper output) : TestBase<Reac
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -74,7 +75,7 @@ public class ReactiveCMDGeneratorTests(ITestOutputHelper output) : TestBase<Reac
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -108,7 +109,7 @@ public class ReactiveCMDGeneratorTests(ITestOutputHelper output) : TestBase<Reac
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -143,6 +144,8 @@ public class ReactiveCMDGeneratorTests(ITestOutputHelper output) : TestBase<Reac
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
+
+    private SettingsTask VerifyGenerator(GeneratorDriver driver) => Verify(driver).UseDirectory(TestHelper.VerifiedFilePath()).ScrubLinesContaining("[global::System.CodeDom.Compiler.GeneratedCode(\"");
 }

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveGeneratorTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.CodeAnalysis;
 using ReactiveUI.SourceGenerators;
 using Xunit.Abstractions;
 
@@ -41,7 +42,7 @@ public class ReactiveGeneratorTests(ITestOutputHelper output) : TestBase<Reactiv
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -71,7 +72,7 @@ public class ReactiveGeneratorTests(ITestOutputHelper output) : TestBase<Reactiv
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
 
     /// <summary>
@@ -105,6 +106,8 @@ public class ReactiveGeneratorTests(ITestOutputHelper output) : TestBase<Reactiv
         var driver = TestHelper.TestPass(sourceCode);
 
         // Assert: Verify the generated code.
-        return Verify(driver).UseDirectory(TestHelper.VerifiedFilePath());
+        return VerifyGenerator(driver);
     }
+
+    private SettingsTask VerifyGenerator(GeneratorDriver driver) => Verify(driver).UseDirectory(TestHelper.VerifiedFilePath()).ScrubLinesContaining("[global::System.CodeDom.Compiler.GeneratedCode(\"");
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update for tests to support version 2.0.x.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Tests are reliant on Generator version

**What is the new behavior?**
<!-- If this is a feature change -->

Tests updated to remove the version from the generator output before the test is executed.

**What might this PR break?**

No breaking changes expected.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been updated (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

