### PR TITLE
FIx For IViewFor with Generic Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,23 @@ The class must inherit from a UI Control from any of the following platforms and
 - Avalonia (Avalonia)
 - Uno (Windows.UI.Xaml).
 
+### Usage IViewFor with ViewModel Name - Generic Types should be used with the fully qualified name, otherwise use nameof(ViewModelTypeName)
+```csharp
+using ReactiveUI.SourceGenerators;
+
+[IViewFor("MyReactiveGenericClass<int>")]
+public partial class MyReactiveControl : UserControl
+{
+    public MyReactiveControl()
+    {
+        InitializeComponent();
+        MyReactiveClass = new MyReactiveClass();
+    }
+}
+```
+
+### Usage IViewFor with ViewModel Type
+
 ```csharp
 using ReactiveUI.SourceGenerators;
 

--- a/src/ReactiveUI.SourceGenerators/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators/AttributeDefinitions.cs
@@ -207,6 +207,18 @@ namespace ReactiveUI.SourceGenerators;
 [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.IViewForGenerator", "1.1.0.0")]
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 internal sealed class IViewForAttribute<T> : Attribute;
+
+/// <summary>
+/// IViewForAttribute.
+/// </summary>
+/// <seealso cref="System.Attribute" />
+/// <remarks>
+/// Initializes a new instance of the <see cref="IViewForAttribute"/> class.
+/// </remarks>
+/// <param name="viewModelType">Type of the view model.</param>
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.IViewForGenerator", "1.1.0.0")]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+internal sealed class IViewForAttribute(string? viewModelType) : Attribute;
 #nullable restore
 #pragma warning restore
 """;

--- a/src/ReactiveUI.SourceGenerators/IViewFor/IViewForGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators/IViewFor/IViewForGenerator.Execute.cs
@@ -50,9 +50,11 @@ public partial class IViewForGenerator
 
         token.ThrowIfCancellationRequested();
 
+        var constructorArgument = attributeData.GetConstructorArguments<string>().FirstOrDefault();
         var genericArgument = attributeData.GetGenericType();
         token.ThrowIfCancellationRequested();
-        if (!(genericArgument is string viewModelTypeName && viewModelTypeName.Length > 0))
+        var viewModelTypeName = string.IsNullOrWhiteSpace(constructorArgument) ? genericArgument : constructorArgument;
+        if (string.IsNullOrWhiteSpace(viewModelTypeName))
         {
             return default;
         }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Using a Generic ViewModel is not supported with the Generic Attribute

**What is the new behavior?**
<!-- If this is a feature change -->

A second attribute has been added allowing the fully qualified name to be passed as a string

**What might this PR break?**

This functionality existed previously and was changed to allow simpler Generic attribute declarations however the fact that it did not support Generic types to be used was unknown, first release with this change was 2.0.9

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

