### PR TITLE
Fix For Generators used on Generic class

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel2.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel2.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+
+namespace SGReactiveUI.SourceGenerators.Test;
+
+/// <summary>
+/// TestViewModel2.
+/// </summary>
+/// <typeparam name="T">the type.</typeparam>
+/// <seealso cref="ReactiveUI.ReactiveObject" />
+public partial class TestViewModel2<T> : ReactiveObject
+{
+    [Reactive]
+    private bool _IsTrue;
+}

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf2.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf2.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+using ReactiveUI.SourceGenerators;
+
+namespace SGReactiveUI.SourceGenerators.Test;
+
+/// <summary>
+/// TestViewWpf2.
+/// </summary>
+/// <seealso cref="System.Windows.Window" />
+[IViewFor("TestViewModel2<int>")]
+public partial class TestViewWpf2 : Window
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestViewWpf2"/> class.
+    /// </summary>
+    public TestViewWpf2() => ViewModel = new();
+}

--- a/src/ReactiveUI.SourceGenerators/Core/Models/HierarchyInfo.Syntax.cs
+++ b/src/ReactiveUI.SourceGenerators/Core/Models/HierarchyInfo.Syntax.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/ReactiveUI.SourceGenerators/Core/Models/TargetInfo.cs
+++ b/src/ReactiveUI.SourceGenerators/Core/Models/TargetInfo.cs
@@ -3,9 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
@@ -22,8 +19,8 @@ internal sealed partial record TargetInfo(
 {
     public static TargetInfo From(INamedTypeSymbol namedTypeSymbol)
     {
-        var targetHintName = namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-        var targetName = namedTypeSymbol.Name;
+        var targetHintName = namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat).Replace("<", "_").Replace(">", "_");
+        var targetName = namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
         var targetNamespace = namedTypeSymbol.ContainingNamespace.ToDisplayString(SymbolHelpers.DefaultDisplay);
         var targetNameWithNamespace = namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
         var targetAccessibility = namedTypeSymbol.GetAccessibilityString();


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes #115 

Relies On #118 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Version 2.0.9 uses a different method to create a HintName for the source code output to previous versions

**What is the new behavior?**
<!-- If this is a feature change -->

HintName has been modified to accept Generic Class Names within the output of the Generator "<" or ">" are replaced with "_"

**What might this PR break?**

Fixes a regression in functionality

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

