### PR TITLE
Fix for Nullable partial OAPH properties

### DIFF
--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -21,7 +21,7 @@ namespace TestNs
         /// <inheritdoc cref="_testProperty"/>
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
-        public partial double? TestProperty { get => _testProperty = _testPropertyHelper?.Value ?? _testProperty; }
+        public partial double? TestProperty { get => _testProperty = (_testPropertyHelper == null ? _testProperty : _testPropertyHelper.Value); }
 
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()

--- a/src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs
@@ -24,6 +24,9 @@ public partial class TestClassOAPH_VM : ReactiveObject
     private string value = string.Empty;
 #pragma warning restore SX1309 // Field names should begin with underscore
 
+    [Reactive]
+    private string? _testProperty;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="TestClassOAPH_VM"/> class.
     /// </summary>
@@ -34,6 +37,21 @@ public partial class TestClassOAPH_VM : ReactiveObject
 
         _observableTestFieldHelper = this.WhenAnyValue(x => x.ReactiveTestField)
             .ToProperty(this, x => x.ObservableTestField);
+
+        _testHelper = this.WhenAnyValue(x => x.TestProperty).ToProperty(this, x => x.Test);
+
+        TestProperty = null;
+        var t0 = Test;
+
+        TestProperty = "Test";
+
+        var t1 = Test;
+
+        TestProperty = null;
+        var t2 = Test;
+
+        TestProperty = "Test2";
+        var t3 = Test;
     }
 
     /// <summary>
@@ -53,4 +71,13 @@ public partial class TestClassOAPH_VM : ReactiveObject
     /// </value>
     [Reactive]
     public partial bool ReactiveTestProperty { get; set; }
+
+    /// <summary>
+    /// Gets the test.
+    /// </summary>
+    /// <value>
+    /// The test.
+    /// </value>
+    [ObservableAsProperty]
+    public partial string? Test { get; }
 }

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -21,6 +21,9 @@ namespace SGReactiveUI.SourceGenerators.Test;
 /// <summary>
 /// TestClass.
 /// </summary>
+/// <seealso cref="ReactiveUI.ReactiveObject" />
+/// <seealso cref="ReactiveUI.IActivatableViewModel" />
+/// <seealso cref="System.IDisposable" />
 /// <seealso cref="ReactiveObject" />
 /// <seealso cref="IActivatableViewModel" />
 /// <seealso cref="IDisposable" />
@@ -217,6 +220,14 @@ public partial class TestViewModel : ReactiveObject, IActivatableViewModel, IDis
     /// The instance.
     /// </value>
     public static TestViewModel Instance { get; } = new();
+
+    /// <summary>
+    /// Gets the test class oaph vm.
+    /// </summary>
+    /// <value>
+    /// The test class oaph vm.
+    /// </value>
+    public TestClassOAPH_VM TestClassOAPH_VM { get; } = new();
 
     /// <summary>
     /// Gets or sets the partial property test.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
@@ -307,7 +307,7 @@ $$"""
     {
         var propertyAttributes = string.Join("\n        ", AttributeDefinitions.ExcludeFromCodeCoverage.Concat(propertyInfo.ForwardedPropertyAttributes));
         var getterFieldIdentifierName = propertyInfo.GetGeneratedFieldName();
-        var getterArrowExpression = propertyInfo.IsNullableType
+        var getterArrowExpression = propertyInfo.IsNullableType || propertyInfo.IsFromPartialProperty
             ? $"{getterFieldIdentifierName} = ({getterFieldIdentifierName}Helper == null ? {getterFieldIdentifierName} : {getterFieldIdentifierName}Helper.Value)"
             : $"{getterFieldIdentifierName} = {getterFieldIdentifierName}Helper?.Value ?? {getterFieldIdentifierName}";
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix for #197

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#197

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request includes several changes to the `ReactiveUI.SourceGenerators` project, focusing on improving the handling of observable properties and enhancing the test view models. The most important changes include modifying property getters, adding new properties and attributes, and updating the test view models.

Improvements to property getters:

* [`src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs`](diffhunk://#diff-6334f59c8f1dc2da01174924580409cf3948da137de3fc2f73ae41c0084a57d3L24-R24): Modified the getter for `TestProperty` to handle the case where `_testPropertyHelper` is null more explicitly.
* [`src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs`](diffhunk://#diff-d9f8b6812477e2359e5b3ac9d0c1108b91119e33753382240e30b856f3fba3c7L310-R310): Updated the `GetPropertySyntax` method to account for properties from partial classes when determining the getter arrow expression.

Enhancements to test view models:

* [`src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs`](diffhunk://#diff-451acb547828b9be9b080ad46f9f52b184d0db0e7b0848515c469355508d70d7R27-R29): Added a new private field `_testProperty` and initialized it in the constructor. Also, added a new observable property `Test` with corresponding initialization logic. [[1]](diffhunk://#diff-451acb547828b9be9b080ad46f9f52b184d0db0e7b0848515c469355508d70d7R27-R29) [[2]](diffhunk://#diff-451acb547828b9be9b080ad46f9f52b184d0db0e7b0848515c469355508d70d7R40-R54) [[3]](diffhunk://#diff-451acb547828b9be9b080ad46f9f52b184d0db0e7b0848515c469355508d70d7R74-R82)
* [`src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs`](diffhunk://#diff-13417a514976e5b59a11c29f1c937ef0e1a9647b7d8b820c901e89e54e1242c3R224-R231): Added a new property `TestClassOAPH_VM` to the `TestViewModel` class to encapsulate an instance of `TestClassOAPH_VM`.

Documentation improvements:

* [`src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs`](diffhunk://#diff-13417a514976e5b59a11c29f1c937ef0e1a9647b7d8b820c901e89e54e1242c3R24-R26): Added `seealso` references to the `TestClass` documentation to improve clarity and maintainability.

Nullable partial properties with ObservableAsProperty are not updated with null value
Adds check for partial properties to allow a null value after a value

**What might this PR break?**

Code is corrected for output, which may have lead to incorrect current value.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

