### PR TITLE
Fix for required keyword on partial properties

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -228,6 +228,15 @@ public partial class TestViewModel : ReactiveObject, IActivatableViewModel, IDis
     public partial string? PartialPropertyTest { get; set; }
 
     /// <summary>
+    /// Gets or sets the partial property test.
+    /// </summary>
+    /// <value>
+    /// The partial property test.
+    /// </value>
+    [Reactive(UseRequired = true)]
+    public required partial string? PartialRequiredPropertyTest { get; set; }
+
+    /// <summary>
     /// Gets the internal test property. Should not prompt to replace with INPC Reactive Property.
     /// </summary>
     /// <value>

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
@@ -72,7 +72,10 @@ public sealed partial class ReactiveGenerator
         token.ThrowIfCancellationRequested();
 
         var inheritance = propertySymbol.IsVirtual ? " virtual" : propertySymbol.IsOverride ? " override" : string.Empty;
-        var useRequired = string.Empty;
+
+        attributeData.TryGetNamedArgument("UseRequired", out bool useRequiredArgument);
+        var useRequired = useRequiredArgument ? "required " : string.Empty;
+
         var typeNameWithNullabilityAnnotations = propertySymbol.Type.GetFullyQualifiedNameWithNullabilityAnnotations();
         var fieldName = propertySymbol.GetGeneratedFieldName();
         var propertyName = propertySymbol.Name;
@@ -326,7 +329,7 @@ $$"""
         {{fieldSyntax}}
         /// <inheritdoc cref="{{fieldName}}"/>
         {{propertyAttributes}}
-        {{propertyInfo.TargetInfo.TargetVisibility}}{{propertyInfo.Inheritance}} {{partialModifier}}{{propertyInfo.UseRequired}}{{propertyInfo.TypeNameWithNullabilityAnnotations}} {{propertyInfo.PropertyName}}
+        {{propertyInfo.TargetInfo.TargetVisibility}}{{propertyInfo.Inheritance}} {{propertyInfo.UseRequired}}{{partialModifier}}{{propertyInfo.TypeNameWithNullabilityAnnotations}} {{propertyInfo.PropertyName}}
         { 
             get => {{propertyInfo.FieldName}};
             [global::System.Diagnostics.CodeAnalysis.MemberNotNull("{{fieldName}}")]


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix for #208 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#208 

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request introduces changes to the ReactiveUI source generators to support the `UseRequired` attribute for properties. The most important changes include adding a new property with the `UseRequired` attribute, updating the generator to handle the new attribute, and modifying the property syntax generation to include the `required` keyword when applicable.

Support for `UseRequired` attribute:

* [`src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs`](diffhunk://#diff-13417a514976e5b59a11c29f1c937ef0e1a9647b7d8b820c901e89e54e1242c3R230-R238): Added a new property `PartialRequiredPropertyTest` with the `UseRequired` attribute set to true.

Generator updates:

* [`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs`](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L75-R78): Updated the `ReactiveGenerator` class to parse the `UseRequired` attribute and use it when generating property code.

Property syntax generation:

* [`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs`](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L329-R332): Modified the `GetPropertySyntax` method to include the `required` keyword in the generated property syntax when the `UseRequired` attribute is present.

**What might this PR break?**

None as code generation would have failed when used in this manner

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

