### PR TITLE
Housekeeping update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) ReactiveUI 2023-2025
+Copyright (c) ReactiveUI and contributors 2023-2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -17,7 +17,7 @@
     <PackageReleaseNotes>https://github.com/reactiveui/ReactiveUI.SourceGenerators/releases</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/reactiveui/reactiveui.sourcegenerators</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <NoWarn>$(NoWarn);IDE0060;IDE1006;IDE0130;VSSpell001;RS2007;NU5128</NoWarn>
+    <NoWarn>$(NoWarn);IDE0060;IDE1006;IDE0130;VSSpell001;RS2007;RS1038;NU5128</NoWarn>
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Embed source files that are not tracked by the source control manager in the PDB -->

--- a/src/ReactiveUI.SourceGenerator.Tests/ModuleInitializer.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/ModuleInitializer.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;

--- a/src/ReactiveUI.SourceGenerator.Tests/TestBase.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/TestBase.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerator.Tests/TestHelper.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/TestHelper.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using FluentAssertions;

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/BindableDerivedListGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/BindableDerivedListGeneratorTests.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPFromObservableGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPFromObservableGeneratorTests.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPGeneratorTests.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveGeneratorTests.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/FieldSyntaxExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/FieldSyntaxExtensions.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ISymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ISymbolExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ITypeSymbolExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/EquatableArray{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/EquatableArray{T}.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/HashCode.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/HashCode.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/ImmutableArrayBuilder{T}.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldAnalyzer.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldAnalyzer.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldCodeFixProvider.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldCodeFixProvider.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/DiagnosticDescriptors.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Execute.Maui/IViewForTest.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Maui/IViewForTest.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Execute.Maui/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Maui/TestViewModel.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Reactive;

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested1/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested1/Class1.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested2/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested2/Class1.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested3/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested3/Class1.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested3/Nested4/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested3/Nested4/Class1.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute/Person.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/Person.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute/Program.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/Program.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace SGReactiveUI.SourceGenerators.Test;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestAttribute.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestAttribute.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace SGReactiveUI.SourceGenerators.Test;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.ObjectModel;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel2.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel2.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel3.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel3.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel{partTwo}.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel{partTwo}.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWinForms.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWinForms.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf2.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf2.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Windows;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsRCHost.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsRCHost.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.WinForms;

--- a/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsVMCHost.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsVMCHost.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.WinForms;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.Execute.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/Models/BindableDerivedListInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/Models/BindableDerivedListInfo.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/AttributeDataExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/AttributeDataExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/CompilationExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/CompilationExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/DiagnosticsExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/DiagnosticsExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/FieldSyntaxExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/FieldSyntaxExtensions.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ISymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ISymbolExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SymbolInfoExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SymbolInfoExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxTokenExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxTokenExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxValueProviderExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxValueProviderExtensions.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/AttributeInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/AttributeInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/EquatableArray{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/EquatableArray{T}.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/HashCode.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/HashCode.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.ComponentModel;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/ImmutableArrayBuilder{T}.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/SymbolHelpers.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/SymbolHelpers.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.Factory.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.Factory.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/DiagnosticInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/DiagnosticInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/GenericGeneratorAttributeSyntaxContext.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/GenericGeneratorAttributeSyntaxContext.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/PropertyAttributeData.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/PropertyAttributeData.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace ReactiveUI.SourceGenerators.Models;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/Result.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/Result.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/TargetInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/TargetInfo.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/DiagnosticDescriptors.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/SuppressionDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/SuppressionDescriptors.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.CodeAnalysis;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/OAPHMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/OAPHMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ObservableAsPropertyAttributeWithFieldNeverReadDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ObservableAsPropertyAttributeWithFieldNeverReadDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithPropertyTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithPropertyTargetDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandAttributeWithFieldOrPropertyTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandAttributeWithFieldOrPropertyTargetDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveFieldDoesNotNeedToBeReadOnlyDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveFieldDoesNotNeedToBeReadOnlyDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Linq;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForBaseType.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForBaseType.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace ReactiveUI.SourceGenerators.Input.Models;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableFieldInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableFieldInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableMethodInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableMethodInfo.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Globalization;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Text;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CanExecuteTypeInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CanExecuteTypeInfo.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 namespace ReactiveUI.SourceGenerators.Input.Models;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CommandInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CommandInfo.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/Models/RoutedControlHostInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/Models/RoutedControlHostInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/Models/ViewModelControlHostInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/Models/ViewModelControlHostInfo.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.cs
@@ -1,6 +1,6 @@
-// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -12,8 +12,8 @@
             "documentInterfaces": true,
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
-            "companyName": ".NET Foundation and Contributors",
-            "copyrightText": "Copyright (c) 2024 {companyName}. All rights reserved.\nLicensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "companyName": "ReactiveUI and contributors",
+            "copyrightText": "Copyright (c) 2025 {companyName}. All rights reserved.\nLicensed to the {companyName} under one or more agreements.\nThe {companyName} licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Outdated copyright details

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request includes updates to licensing information across various files and a modification to the build properties. The most important changes include updating the copyright information and adding a new warning suppression.

Licensing updates:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright to include "ReactiveUI and contributors".
* Updated copyright information in multiple test files and code fix files.

Build properties update:

* [`src/Directory.build.props`](diffhunk://#diff-a977439a271df79c88284a87b9c965846c6822775f8e204e9c3c96766696188cL20-R20): Added `RS1038` to the `NoWarn` list to suppress additional warnings.

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

