### PR TITLE
Fix support for classes implementing IReactiveObject without inheriting from ReactiveObject

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/FieldSyntaxExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/FieldSyntaxExtensions.cs
@@ -17,7 +17,7 @@ internal static class FieldSyntaxExtensions
     internal static bool IsTargetTypeValid(this IFieldSymbol fieldSymbol)
     {
         var isObservableObject = fieldSymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.ReactiveObject");
-        var isIObservableObject = fieldSymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
+        var isIObservableObject = fieldSymbol.ContainingType.ImplementsFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
         var hasObservableObjectAttribute = fieldSymbol.ContainingType.HasOrInheritsAttributeWithFullyQualifiedMetadataName("ReactiveUI.SourceGenerators.ReactiveObjectAttribute");
 
         return isIObservableObject || isObservableObject || hasObservableObjectAttribute;
@@ -31,7 +31,7 @@ internal static class FieldSyntaxExtensions
     internal static bool IsTargetTypeValid(this IPropertySymbol propertySymbol)
     {
         var isObservableObject = propertySymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.ReactiveObject");
-        var isIObservableObject = propertySymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
+        var isIObservableObject = propertySymbol.ContainingType.ImplementsFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
         var hasObservableObjectAttribute = propertySymbol.ContainingType.HasOrInheritsAttributeWithFullyQualifiedMetadataName("ReactiveUI.SourceGenerators.ReactiveObjectAttribute");
 
         return isIObservableObject || isObservableObject || hasObservableObjectAttribute;

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ITypeSymbolExtensions.cs
@@ -38,6 +38,25 @@ internal static class ITypeSymbolExtensions
     }
 
     /// <summary>
+    /// Checks whether or not a given <see cref="ITypeSymbol"/> implements a specified interface.
+    /// </summary>
+    /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
+    /// <param name="name">The full name of the interface to check for inheritance.</param>
+    /// <returns>Whether or not <paramref name="typeSymbol"/> implements <paramref name="name"/>.</returns>
+    public static bool ImplementsFullyQualifiedMetadataName(this ITypeSymbol typeSymbol, string name)
+    {
+        foreach (var implementedInterface in typeSymbol.AllInterfaces)
+        {
+            if (implementedInterface.HasFullyQualifiedMetadataName(name))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Checks whether or not a given <see cref="ITypeSymbol"/> has or inherits a specified attribute.
     /// </summary>
     /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/FieldSyntaxExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/FieldSyntaxExtensions.cs
@@ -123,7 +123,7 @@ internal static class FieldSyntaxExtensions
     internal static bool IsTargetTypeValid(this IFieldSymbol fieldSymbol)
     {
         var isObservableObject = fieldSymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.ReactiveObject");
-        var isIObservableObject = fieldSymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
+        var isIObservableObject = fieldSymbol.ContainingType.ImplementsFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
         var hasObservableObjectAttribute = fieldSymbol.ContainingType.HasOrInheritsAttributeWithFullyQualifiedMetadataName("ReactiveUI.SourceGenerators.ReactiveObjectAttribute");
 
         return isIObservableObject || isObservableObject || hasObservableObjectAttribute;
@@ -137,7 +137,7 @@ internal static class FieldSyntaxExtensions
     internal static bool IsTargetTypeValid(this IPropertySymbol propertySymbol)
     {
         var isObservableObject = propertySymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.ReactiveObject");
-        var isIObservableObject = propertySymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
+        var isIObservableObject = propertySymbol.ContainingType.ImplementsFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
         var hasObservableObjectAttribute = propertySymbol.ContainingType.HasOrInheritsAttributeWithFullyQualifiedMetadataName("ReactiveUI.SourceGenerators.ReactiveObjectAttribute");
 
         return isIObservableObject || isObservableObject || hasObservableObjectAttribute;
@@ -151,7 +151,7 @@ internal static class FieldSyntaxExtensions
     internal static bool IsTargetTypeValid(this IMethodSymbol methodSymbol)
     {
         var isObservableObject = methodSymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.ReactiveObject");
-        var isIObservableObject = methodSymbol.ContainingType.InheritsFromFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
+        var isIObservableObject = methodSymbol.ContainingType.ImplementsFullyQualifiedMetadataName("ReactiveUI.IReactiveObject");
         var hasObservableObjectAttribute = methodSymbol.ContainingType.HasOrInheritsAttributeWithFullyQualifiedMetadataName("ReactiveUI.SourceGenerators.ReactiveObjectAttribute");
 
         return isIObservableObject || isObservableObject || hasObservableObjectAttribute;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
@@ -57,6 +57,25 @@ internal static class ITypeSymbolExtensions
     }
 
     /// <summary>
+    /// Checks whether or not a given <see cref="ITypeSymbol"/> implements a specified interface.
+    /// </summary>
+    /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
+    /// <param name="name">The full name of the interface to check for inheritance.</param>
+    /// <returns>Whether or not <paramref name="typeSymbol"/> implements <paramref name="name"/>.</returns>
+    public static bool ImplementsFullyQualifiedMetadataName(this ITypeSymbol typeSymbol, string name)
+    {
+        foreach (var implementedInterface in typeSymbol.AllInterfaces)
+        {
+            if (implementedInterface.HasFullyQualifiedMetadataName(name))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Checks whether or not a given <see cref="ITypeSymbol"/> has or inherits from a specified type.
     /// </summary>
     /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixes bug #224

**What is the current behavior?**
Build error when the containing class of a property marked with [Reactive] implements IReactiveObject but does not inherit from ReactiveObject

**What is the new behavior?**
Works with classes implementing IReactiveObject without inheriting from ReactiveObject

**What might this PR break?**
Nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)