### PR TITLE
Housekeeping fix file header

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithFieldTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithFieldTargetDiagnosticSuppressor.cs
@@ -1,6 +1,6 @@
-﻿// Copyright (c) 2024 .NET Foundation and Contributors. All rights reserved.
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request updates the copyright information in the `ReactiveAttributeWithFieldTargetDiagnosticSuppressor.cs` file to reflect the correct year and organization.

* [`src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithFieldTargetDiagnosticSuppressor.cs`](diffhunk://#diff-a393270c763c06ea65e85849b02b6062c6083629a6ba33ad37bbd6d1004aa9b8L1-R3): Updated copyright year from 2024 to 2025 and changed the organization name from ".NET Foundation" to "ReactiveUI and contributors."
