### PR TITLE
Feature Enable Partial Reactive Properties to have initializer

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/InternalTestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/InternalTestViewModel.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Licensed to the ReactiveUI and contributors under one or more agreements.
+// The ReactiveUI and contributors licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+
+namespace SGReactiveUI.SourceGenerators.Test;
+
+internal partial class InternalTestViewModel : ReactiveObject
+{
+    [Reactive]
+    public partial int PublicPartialPropertyTest { get; set; }
+
+    [Reactive]
+    public partial int PublicPartialPropertyWithInternalProtectedTest { get; protected internal set; }
+
+    [Reactive]
+    public partial int PublicPartialPropertyWithPrivateProtectedTest { get; private protected set; }
+
+    [Reactive]
+    public partial int PublicPartialPropertyWithProtectedTest { get; protected set; }
+
+    [Reactive]
+    public partial int PublicPartialPropertyWithInternalTest { get; internal set; }
+
+    [Reactive]
+    public partial int PublicPartialPropertyWithPrivateTest { get; private set; }
+
+    [Reactive]
+    internal partial int InternalPartialPropertyTest { get; set; }
+
+    [Reactive]
+    protected internal partial int InternalProtectedPartialPropertyTest { get; set; }
+
+    [Reactive]
+    protected partial int ProtectedPartialPropertyTest { get; set; }
+
+    [Reactive]
+    private partial int PrivatePartialPropertyTest { get; set; }
+}

--- a/src/ReactiveUI.SourceGenerators.Execute/ReactiveUI.SourceGenerators.Execute.csproj
+++ b/src/ReactiveUI.SourceGenerators.Execute/ReactiveUI.SourceGenerators.Execute.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <LangVersion>13.0</LangVersion>
+    <NoWarn>$(NoWarn);CA1812</NoWarn>
     <PackageDescription>A MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. This is the Source Generators package for ReactiveUI</PackageDescription>
   </PropertyGroup>
 

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -331,6 +331,9 @@ public partial class TestViewModel : ReactiveObject, IActivatableViewModel, IDis
     [ObservableAsProperty(InitialValue = "10")]
     public partial int ObservableAsPropertyFromProperty { get; }
 
+    [Reactive]
+    internal partial int InternalPartialPropertyTest { get; set; }
+
     [ObservableAsProperty]
     private IObservable<object> ReferenceTypeObservable { get; }
 

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
@@ -19,7 +19,8 @@ internal sealed record PropertyInfo(
     bool IsReferenceTypeOrUnconstrainedTypeParameter,
     bool IncludeMemberNotNullOnSetAccessor,
     EquatableArray<string> ForwardedAttributes,
-    string AccessModifier,
+    string SetAccessModifier,
     string Inheritance,
     string UseRequired,
-    bool IsProperty);
+    bool IsProperty,
+    string PropertyAccessModifier);


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

fixes #222 

**What is the new behavior?**
<!-- If this is a feature change -->

The main feature addition is to enable Partial Reactive Properties to use initializers, the consuming project must use the Preview version of C# to enable this.

This pull request also introduces several updates and improvements to the ReactiveUI source generators, focusing on property access modifiers, code generation logic, and internal test models. The key changes include the addition of new reactive properties in test view models, updates to property access modifier handling, and enhancements to code generation syntax.

### Enhancements to Property Access Modifiers:

* Updated the `PropertyInfo` record to distinguish between `SetAccessModifier` and `PropertyAccessModifier` for more precise handling of property access levels. (`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs`, [src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.csL22-R26](diffhunk://#diff-a90a59ab1e3a9965c0bf96a01c585ef360a7c38f6c1dfb080308d2ce1b8f0e33L22-R26))
* Refactored the `ReactiveGenerator` to improve the handling of `SetAccessModifier` and `PropertyAccessModifier`, ensuring proper formatting and consistency for different access levels (e.g., `protected internal`, `private protected`). (`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs`, [[1]](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L62-R116) [[2]](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L114-R171) [[3]](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L159-R218)

### Improvements to Code Generation:

* Enhanced the `GetPropertySyntax` method to correctly handle access modifiers and improve the generated property syntax, ensuring better alignment with the intended behavior. (`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs`, [src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.csL318-R413](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L318-R413))
* Adjusted the `GenerateParentClassDeclarations` method to use a more concise syntax with array slicing for property parent information. (`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs`, [src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.csL258-R313](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73L258-R313))

### Additions to Test Models:

* Added a comprehensive set of reactive properties with varying access levels (e.g., `public`, `internal`, `protected`, `private`) to the `InternalTestViewModel` for testing purposes. (`src/ReactiveUI.SourceGenerators.Execute/InternalTestViewModel.cs`, [src/ReactiveUI.SourceGenerators.Execute/InternalTestViewModel.csR1-R42](diffhunk://#diff-863a0a7726d957352ee1ed0bcf64b7c665ec5e8dbfacba9facb0658dc38b7d8dR1-R42))
* Introduced a new internal reactive property in the `TestViewModel` to expand test coverage. (`src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs`, [src/ReactiveUI.SourceGenerators.Execute/TestViewModel.csR334-R336](diffhunk://#diff-13417a514976e5b59a11c29f1c937ef0e1a9647b7d8b820c901e89e54e1242c3R334-R336))

### Miscellaneous Updates:

* Suppressed the `CA1812` warning in the project file to address unused internal types during compilation. (`src/ReactiveUI.SourceGenerators.Execute/ReactiveUI.SourceGenerators.Execute.csproj`, [src/ReactiveUI.SourceGenerators.Execute/ReactiveUI.SourceGenerators.Execute.csprojR12](diffhunk://#diff-b5e9b52263596df33d1a462ec79a15514004a3e573e18abb57bc314fc3b5dce3R12))
* Added a reference to `Microsoft.CodeAnalysis.CSharp` for additional syntax analysis capabilities. (`src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs`, [src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.csR11](diffhunk://#diff-33613fa70999146f39a0ad4f9254adb776227d366597e86c82e1eb1af86f0b73R11))

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

