### PR TITLE
Fix Attribute On Partial Reactive Property Is Duplicated

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -237,6 +237,7 @@ public partial class TestViewModel : ReactiveObject, IActivatableViewModel, IDis
     /// </value>
     [Reactive]
     [field: JsonInclude]
+    [JsonPropertyName("test")]
     public partial string? PartialPropertyTest { get; set; }
 
     /// <summary>

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
@@ -210,7 +210,7 @@ internal static class ITypeSymbolExtensions
         return false;
     }
 
-    public static bool IsIShedulerType(this ITypeSymbol? typeSymbol)
+    public static bool IsISchedulerType(this ITypeSymbol? typeSymbol)
     {
         var nameFormat = SymbolDisplayFormat.FullyQualifiedFormat;
         do

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
@@ -378,15 +378,29 @@ $$"""
 
         var fieldSyntax = string.Empty;
         var partialModifier = propertyInfo.IsProperty ? "partial " : string.Empty;
+        string propertyAttributes;
+
         if (propertyInfo.IsProperty && propertyInfo.FieldName != "field")
         {
-            fieldSyntax = $"private {propertyInfo.TypeNameWithNullabilityAnnotations} {propertyInfo.FieldName};";
+            propertyAttributes = string.Join("\n        ", propertyInfo.ForwardedAttributes);
+            fieldSyntax =
+$$"""
+{{propertyAttributes}}
+        private {{propertyInfo.TypeNameWithNullabilityAnnotations}} {{propertyInfo.FieldName}};
+""";
+        }
+
+        if (propertyInfo.IsProperty)
+        {
+            propertyAttributes = string.Join("\n        ", AttributeDefinitions.ExcludeFromCodeCoverage);
+        }
+        else
+        {
+            propertyAttributes = string.Join("\n        ", AttributeDefinitions.ExcludeFromCodeCoverage.Concat(propertyInfo.ForwardedAttributes));
         }
 
         var accessModifier = propertyInfo.PropertyAccessModifier;
         var setAccessModifier = propertyInfo.SetAccessModifier;
-
-        var propertyAttributes = string.Join("\n        ", AttributeDefinitions.ExcludeFromCodeCoverage.Concat(propertyInfo.ForwardedAttributes));
 
         if (propertyInfo.IncludeMemberNotNullOnSetAccessor || propertyInfo.IsReferenceTypeOrUnconstrainedTypeParameter)
         {

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -352,7 +352,7 @@ $$"""
         if (outputSchedulerSymbol is IFieldSymbol outputSchedulerFieldSymbol)
         {
             // The property type must always be a bool
-            if (!outputSchedulerFieldSymbol.Type.IsIShedulerType())
+            if (!outputSchedulerFieldSymbol.Type.IsISchedulerType())
             {
                 goto Failure;
             }
@@ -363,7 +363,7 @@ $$"""
         else if (outputSchedulerSymbol is IPropertySymbol { GetMethod: not null } outputSchedulerPropertySymbol)
         {
             // The property type must always be a bool
-            if (!outputSchedulerPropertySymbol.Type.IsIShedulerType())
+            if (!outputSchedulerPropertySymbol.Type.IsISchedulerType())
             {
                 goto Failure;
             }
@@ -374,7 +374,7 @@ $$"""
         else if (outputSchedulerSymbol is IMethodSymbol outputSchedulerMethodSymbol)
         {
             // The return type must always be a bool
-            if (!outputSchedulerMethodSymbol.ReturnType.IsIShedulerType())
+            if (!outputSchedulerMethodSymbol.ReturnType.IsISchedulerType())
             {
                 goto Failure;
             }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fixes #245

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#245

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request introduces several changes to improve attribute handling, correct a typo in method names, and enhance the property syntax generation in the `ReactiveUI.SourceGenerators` project. The most important changes include refining the logic for forwarding attributes, fixing a recurring typo in the `IsISchedulerType` method, and updating the property syntax generation to include attribute handling.

### Attribute handling improvements:

* [`src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs`](diffhunk://#diff-13417a514976e5b59a11c29f1c937ef0e1a9647b7d8b820c901e89e54e1242c3R240): Added `[JsonPropertyName("test")]` to the `PartialPropertyTest` property to specify the JSON serialization name.
* [`src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs`](diffhunk://#diff-d3f48ab2241ae2d2731606a0531862c36a53250bf7c4ad7ca76cf64457b86335R30-R37): Updated the `GetForwardedAttributes` method to check for the `[Reactive]` attribute and prevent forwarding attributes without field targets when the property is reactive. [[1]](diffhunk://#diff-d3f48ab2241ae2d2731606a0531862c36a53250bf7c4ad7ca76cf64457b86335R30-R37) [[2]](diffhunk://#diff-d3f48ab2241ae2d2731606a0531862c36a53250bf7c4ad7ca76cf64457b86335R65)

### Typo correction:

* [`src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs`](diffhunk://#diff-c7c195fa5025bf847a2742457a9571fe89c9a0e6090ca4d4fb08304a9e4d52f8L213-R213): Fixed a typo in the method name `IsIShedulerType`, correcting it to `IsISchedulerType`.
* [`src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs`](diffhunk://#diff-858964e8d0fa8ef7c26912909d888c99d02be219a02fc8afa5d5b2d750ae5136L355-R355): Corrected the same typo in multiple locations where `IsIShedulerType` was used in conditional checks. [[1]](diffhunk://#diff-858964e8d0fa8ef7c26912909d888c99d02be219a02fc8afa5d5b2d750ae5136L355-R355) [[2]](diffhunk://#diff-858964e8d0fa8ef7c26912909d888c99d02be219a02fc8afa5d5b2d750ae5136L366-R366) [[3]](diffhunk://#diff-858964e8d0fa8ef7c26912909d888c99d02be219a02fc8afa5d5b2d750ae5136L377-R377)

**What might this PR break?**

None due to build failure in previous versions

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

