### PR TITLE
Fix for partial classes add documentation comments

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="NuGet.Protocol" Version="6.14.0" />
     <PackageVersion Include="stylecop.analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
-    <PackageVersion Include="ReactiveUI" Version="20.3.1" />
+    <PackageVersion Include="ReactiveUI" Version="20.4.1" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
@@ -35,7 +35,7 @@
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
     <PackageVersion Include="Xunit.StaFact" Version="2.1.7" />
-    <PackageVersion Include="FluentAssertions" Version="8.3.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.4.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
     <PackageVersion Include="PublicApiGenerator" Version="11.4.6" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />

--- a/src/ReactiveUI.SourceGenerator.Tests/DERIVEDLIST/BindableDerivedListGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/DERIVEDLIST/BindableDerivedListGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 internal sealed class BindableDerivedListAttribute : global::System.Attribute;
 #nullable restore

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
@@ -4,16 +4,14 @@
 #nullable enable
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="_testPropertyHelper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<double?> _testPropertyHelper;
 
         /// <inheritdoc cref="_testProperty"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test2Property"/>
@@ -19,11 +17,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _test2PropertyHelper;
 
         /// <inheritdoc cref="_test2Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2Property { get => _test2Property = _test2PropertyHelper?.Value ?? _test2Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test3Property"/>
@@ -19,11 +17,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _test3PropertyHelper;
 
         /// <inheritdoc cref="_test3Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test3Property { get => _test3Property = _test3PropertyHelper?.Value ?? _test3Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test1Property"/>
@@ -19,11 +17,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _test1PropertyHelper;
 
         /// <inheritdoc cref="_test1Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1Property { get => _test1Property = _test1PropertyHelper?.Value ?? _test1Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM+TestVMInner1.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM+TestVMInner1.ObservableAsPropertyFromObservable.g.verified.cs
@@ -9,9 +9,7 @@ namespace TestNs
 {
     public partial class TestVM
 {
-/// <summary>
-    /// Partial class for the TestVMInner1 which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     public partial class TestVMInner1
     {
         /// <inheritdoc cref="TestIn1Property"/>
@@ -21,11 +19,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _testIn1PropertyHelper;
 
         /// <inheritdoc cref="_testIn1Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestIn1Property { get => _testIn1Property = _testIn1PropertyHelper?.Value ?? _testIn1Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM+TestVMInner2+TestVMInner3.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM+TestVMInner2+TestVMInner3.ObservableAsPropertyFromObservable.g.verified.cs
@@ -11,9 +11,7 @@ namespace TestNs
 {
 public partial class TestVMInner2
 {
-/// <summary>
-    /// Partial class for the TestVMInner3 which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     public partial class TestVMInner3
     {
         /// <inheritdoc cref="TestIn3Property"/>
@@ -23,11 +21,11 @@ public partial class TestVMInner2
         private ReactiveUI.ObservableAsPropertyHelper<int>? _testIn3PropertyHelper;
 
         /// <inheritdoc cref="_testIn3Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestIn3Property { get => _testIn3Property = _testIn3PropertyHelper?.Value ?? _testIn3Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM+TestVMInner2.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM+TestVMInner2.ObservableAsPropertyFromObservable.g.verified.cs
@@ -9,9 +9,7 @@ namespace TestNs
 {
     public partial class TestVM
 {
-/// <summary>
-    /// Partial class for the TestVMInner2 which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     public partial class TestVMInner2
     {
         /// <inheritdoc cref="TestIn2Property"/>
@@ -21,11 +19,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _testIn2PropertyHelper;
 
         /// <inheritdoc cref="_testIn2Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestIn2Property { get => _testIn2Property = _testIn2PropertyHelper?.Value ?? _testIn2Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test1Property"/>
@@ -19,11 +17,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _test1PropertyHelper;
 
         /// <inheritdoc cref="_test1Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1Property { get => _test1Property = _test1PropertyHelper?.Value ?? _test1Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test5Property"/>
@@ -19,13 +17,13 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _test5PropertyHelper;
 
         /// <inheritdoc cref="_test5Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]
         public int Test5Property { get => _test5Property = _test5PropertyHelper?.Value ?? _test5Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeNullableRef#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeNullableRef#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test7Property"/>
@@ -19,13 +17,13 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<object?>? _test7PropertyHelper;
 
         /// <inheritdoc cref="_test7Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]
         public object? Test7Property { get => _test7Property = (_test7PropertyHelper == null ? _test7Property : _test7PropertyHelper.Value); }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeRef#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeRef#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test6Property"/>
@@ -19,13 +17,13 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<object>? _test6PropertyHelper;
 
         /// <inheritdoc cref="_test6Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]
         public object Test6Property { get => _test6Property = _test6PropertyHelper?.Value ?? _test6Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="Test4Property"/>
@@ -19,11 +17,11 @@ namespace TestNs
         private ReactiveUI.ObservableAsPropertyHelper<int>? _test4PropertyHelper;
 
         /// <inheritdoc cref="_test4Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test4Property { get => _test4Property = _test4PropertyHelper?.Value ?? _test4Property; }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#TestNs.TestVM.ObservableAsPropertyFromObservable.g.verified.cs
@@ -7,9 +7,7 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="TestProperty"/>
@@ -19,12 +17,12 @@ namespace TestNs
         private readonly ReactiveUI.ObservableAsPropertyHelper<double?> _testPropertyHelper;
 
         /// <inheritdoc cref="_testProperty"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         public partial double? TestProperty { get => _testProperty = (_testPropertyHelper == null ? _testProperty : _testPropertyHelper.Value); }
 
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         protected void InitializeOAPH()
         {

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
@@ -4,16 +4,14 @@
 #nullable enable
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="_test1Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test1Helper;
 
         /// <inheritdoc cref="_test1"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1 { get => _test1 = _test1Helper?.Value ?? _test1; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM+TestVMInner1.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM+TestVMInner1.ObservableAsProperties.g.verified.cs
@@ -6,16 +6,14 @@ namespace TestNs
 {
     public partial class TestVM
 {
-/// <summary>
-    /// Partial class for the TestVMInner1 which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     public partial class TestVMInner1
     {
         /// <inheritdoc cref="_testIn1Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _testIn1Helper;
 
         /// <inheritdoc cref="_testIn1"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestIn1 { get => _testIn1 = _testIn1Helper?.Value ?? _testIn1; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM+TestVMInner2+TestVMInner3.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM+TestVMInner2+TestVMInner3.ObservableAsProperties.g.verified.cs
@@ -8,16 +8,14 @@ namespace TestNs
 {
 public partial class TestVMInner2
 {
-/// <summary>
-    /// Partial class for the TestVMInner3 which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     public partial class TestVMInner3
     {
         /// <inheritdoc cref="_testIn3Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _testIn3Helper;
 
         /// <inheritdoc cref="_testIn3"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestIn3 { get => _testIn3 = _testIn3Helper?.Value ?? _testIn3; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM+TestVMInner2.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM+TestVMInner2.ObservableAsProperties.g.verified.cs
@@ -6,16 +6,14 @@ namespace TestNs
 {
     public partial class TestVM
 {
-/// <summary>
-    /// Partial class for the TestVMInner2 which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     public partial class TestVMInner2
     {
         /// <inheritdoc cref="_testIn2Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _testIn2Helper;
 
         /// <inheritdoc cref="_testIn2"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestIn2 { get => _testIn2 = _testIn2Helper?.Value ?? _testIn2; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#TestNs.TestVM.ObservableAsProperties.g.verified.cs
@@ -4,16 +4,14 @@
 #nullable enable
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="_test2Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test2Helper;
 
         /// <inheritdoc cref="_test2"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2 { get => _test2 = _test2Helper?.Value ?? _test2; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
@@ -4,16 +4,14 @@
 #nullable enable
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="_test4Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test4Helper;
 
         /// <inheritdoc cref="_test4"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test4 { get => _test4 = _test4Helper?.Value ?? _test4; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#TestNs.TestVM.ObservableAsProperties.g.verified.cs
@@ -4,16 +4,14 @@
 #nullable enable
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="_test3Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test3Helper;
 
         /// <inheritdoc cref="_test3"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test3 { get => _test3 = _test3Helper?.Value ?? _test3; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromFieldProtected#TestNs.TestVM.ObservableAsProperties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromFieldProtected#TestNs.TestVM.ObservableAsProperties.g.verified.cs
@@ -4,16 +4,14 @@
 #nullable enable
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         /// <inheritdoc cref="_test5Helper"/>
         private readonly ReactiveUI.ObservableAsPropertyHelper<int> _test5Helper;
 
         /// <inheritdoc cref="_test5"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ObservableAsPropertyGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test5 { get => _test5 = _test5Helper?.Value ?? _test5; }
     }

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePartialProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePartialProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#TestNs.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#TestNs.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_test3"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#TestNs.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#TestNs.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_test1"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test1
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#TestNs.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#TestNs.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="this.value"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public string Value
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#TestNs.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#TestNs.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_test2"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int Test2
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#TestNs.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#TestNs.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_name"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#TestNs1.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#TestNs1.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs1
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_name"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#TestNs2.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#TestNs2.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs2
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_name"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         [global::System.Runtime.Serialization.DataMemberAttribute()]
         [global::System.Text.Json.Serialization.JsonIncludeAttribute()]

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#TestNs.TestVM.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#TestNs.TestVM.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs
 {
-    /// <summary>
-    /// Partial class for the TestVM which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestVM
     {
         
         /// <inheritdoc cref="_mustBeSet"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public string MustBeSet
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -13,7 +13,7 @@ namespace ReactiveUI.SourceGenerators;
 /// ReactiveAttribute.
 /// </summary>
 /// <seealso cref="Attribute" />
-[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+[global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
 [global::System.AttributeUsage(global::System.AttributeTargets.Field | global::System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 internal sealed class ReactiveAttribute : global::System.Attribute
 {

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3+TestInnerClass1.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3+TestInnerClass1.Properties.g.verified.cs
@@ -9,14 +9,12 @@ namespace TestNs1
 {
     public partial class TestViewModel3
 {
-/// <summary>
-    /// Partial class for the TestInnerClass1 which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+
     public partial class TestInnerClass1
     {
         
         /// <inheritdoc cref="_testInner1"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestInner1
         { 
@@ -26,7 +24,7 @@ namespace TestNs1
         }
         
         /// <inheritdoc cref="_testInner11"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestInner11
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3+TestInnerClass2+TestInnerClass3.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3+TestInnerClass2+TestInnerClass3.Properties.g.verified.cs
@@ -11,14 +11,12 @@ namespace TestNs1
 {
 public partial class TestInnerClass2
 {
-/// <summary>
-    /// Partial class for the TestInnerClass3 which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+
     public partial class TestInnerClass3
     {
         
         /// <inheritdoc cref="_testInner3"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestInner3
         { 
@@ -28,7 +26,7 @@ public partial class TestInnerClass2
         }
         
         /// <inheritdoc cref="_testInner33"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestInner33
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3+TestInnerClass2.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3+TestInnerClass2.Properties.g.verified.cs
@@ -9,14 +9,12 @@ namespace TestNs1
 {
     public partial class TestViewModel3
 {
-/// <summary>
-    /// Partial class for the TestInnerClass2 which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+
     public partial class TestInnerClass2
     {
         
         /// <inheritdoc cref="_testInner2"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestInner2
         { 
@@ -26,7 +24,7 @@ namespace TestNs1
         }
         
         /// <inheritdoc cref="_testInner22"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public int TestInner22
         { 

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3.Properties.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#TestNs1.TestViewModel3.Properties.g.verified.cs
@@ -7,14 +7,12 @@ using ReactiveUI;
 
 namespace TestNs1
 {
-    /// <summary>
-    /// Partial class for the TestViewModel3 which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+    
     public partial class TestViewModel3
     {
         
         /// <inheritdoc cref="_testVM3Property"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public float TestVM3Property
         { 
@@ -24,7 +22,7 @@ namespace TestNs1
         }
         
         /// <inheritdoc cref="_testVM3Property2"/>
-        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.2.0.0")]
+        [global::System.CodeDom.Compiler.GeneratedCode("ReactiveUI.SourceGenerators.ReactiveGenerator", "2.3.0.0")]
         [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
         public float TestVM3Property2
         { 

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.Execute.cs
@@ -150,9 +150,7 @@ namespace {{containingNamespace}}
 
         return
 $$"""
-/// <summary>
-    /// Partial class for the {{containingTypeName}} which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+
     {{containingClassVisibility}} partial {{containingType}} {{containingTypeName}}
     {
         [global::System.CodeDom.Compiler.GeneratedCode("{{GeneratorName}}", "{{GeneratorVersion}}")]

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
@@ -266,9 +266,6 @@ using Microsoft.Maui.Controls;
 
 namespace {{containingNamespace}}
 {
-    /// <summary>
-    /// Partial class for the {{containingTypeName}} which contains ReactiveUI IViewFor initialization.
-    /// </summary>
     {{forwardedAttributesString}}
     {{containingClassVisibility}} partial {{containingType}} {{containingTypeName}} : IViewFor<{{iviewForInfo.ViewModelTypeName}}>
     {

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
@@ -165,9 +165,7 @@ namespace {{containingNamespace}}
 
         return
 $$"""
-/// <summary>
-    /// Partial class for the {{containingTypeName}} which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     {{containingClassVisibility}} partial {{containingType}} {{containingTypeName}}
     {
 {{propertyDeclarations}}

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
@@ -290,9 +290,7 @@ namespace {{containingNamespace}}
 
         return
 $$"""
-/// <summary>
-    /// Partial class for the {{containingTypeName}} which contains ReactiveUI Observable As Property initialization.
-    /// </summary>
+
     {{containingClassVisibility}} partial {{containingType}} {{containingTypeName}}
     {
         {{propertyDeclarations}}

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
@@ -346,9 +346,7 @@ namespace {{containingNamespace}}
 
         return
 $$"""
-/// <summary>
-    /// Partial class for the {{containingTypeName}} which contains ReactiveUI Reactive property initialization.
-    /// </summary>
+
     {{containingClassVisibility}} partial {{containingType}} {{containingTypeName}}
     {
 {{propertyDeclarations}}

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -160,9 +160,7 @@ namespace {{containingNamespace}}
 
         return
 $$"""
-/// <summary>
-    /// Partial class for the {{containingTypeName}} which contains ReactiveUI ReactiveCommand initialization.
-    /// </summary>
+
     {{containingClassVisibility}} partial {{containingType}} {{containingTypeName}}
     {
 {{commandDeclarations}}


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Closes #268 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#268

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request updates package versions and improves the ReactiveUI source generators by upgrading the generator version used in auto-generated code. Additionally, some redundant XML comments in generated files have been removed.

### Dependency Updates:
* Updated `ReactiveUI` package from version `20.3.1` to `20.4.1` in `src/Directory.Packages.props`.
* Updated `FluentAssertions` package from version `8.3.0` to `8.4.0` in `src/Directory.Packages.props`.

### Source Generator Improvements:
* Upgraded `ReactiveUI.SourceGenerators` from version `2.2.0.0` to `2.3.0.0` in all auto-generated files, ensuring compatibility with the latest generator features. [[1]](diffhunk://#diff-64b6a1fd4b5212d4234ec6e2f6a1498b8818f94ce803b9a5047669e0c562f686L16-R16) [[2]](diffhunk://#diff-3b89553ab5a280a72d5e7aebf2be4b67ed92e9aa5b8056d353506acc2c4d2156L7-R14) [[3]](diffhunk://#diff-c3bd5e84bca63eb68e7224baf5c6822f7d6c07823da597aa15df80f8d110868fL22-R24) and others)

### Code Cleanup:
* Removed redundant XML documentation comments such as class summaries in auto-generated files to improve readability and reduce unnecessary clutter. [[1]](diffhunk://#diff-3b89553ab5a280a72d5e7aebf2be4b67ed92e9aa5b8056d353506acc2c4d2156L7-R14) [[2]](diffhunk://#diff-c3bd5e84bca63eb68e7224baf5c6822f7d6c07823da597aa15df80f8d110868fL10-R10) [[3]](diffhunk://#diff-92738bac1b3fc52c6980c3262de5d91d7a3e16ff231ab036f7e7e1361083a505L10-R10) and others)

**What might this PR break?**

None, resolves an issue

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

