### PR TITLE
Add ReactiveCollection to the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ ReactiveUI Source Generators automatically generate ReactiveUI objects to stream
 - `[RoutedControlHost("YourNameSpace.CustomControl")]`
 - `[ViewModelControlHost("YourNameSpace.CustomControl")]`
 - `[BindableDerivedList]` Generates a derived list from a ReadOnlyObservableCollection backing field
+- `[ReactiveCollection]` Generates property changed notifications on add, remove, new actions on a ObservableCollection backing field
 
 ### Compatibility Notes
 - For ReactiveUI versions **older than V19.5.31**, all `[ReactiveCommand]` options are supported except for async methods with a `CancellationToken`.
@@ -587,6 +588,24 @@ using ReactiveUI.SourceGenerators.WinForms;
 public partial class MyCustomViewModelControlHost;
 ```
 
+### ReactiveCollection
+```csharp
+using System.Collections.ObjectModel;
+using ReactiveUI;
+using ReactiveUI.SourceGenerators;
+
+public partial class MyReactiveClass : ReactiveObject
+{
+    [ReactiveCollection]
+    private ObservableCollection<string> _myCollection;
+
+    public MyReactiveClass()
+    {
+        MyCollection = new ObservableCollection<string>();
+        _myCollection.Add("Item 1");
+    }
+}
+```
 
 ### TODO:
 - Add ObservableAsProperty to generate from a IObservable method with parameters.


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

docs

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request updates the `README.md` to document a new feature in ReactiveUI Source Generators. The new feature introduces the `[ReactiveCollection]` attribute, which generates property change notifications for `ObservableCollection` backing fields. Additionally, an example usage of `[ReactiveCollection]` is provided.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44): Added `[ReactiveCollection]` to the list of attributes, explaining that it generates property change notifications for add, remove, and other actions on an `ObservableCollection` backing field.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R591-R608): Included a code example demonstrating how to use `[ReactiveCollection]` in a `ReactiveObject` class, showcasing its functionality with an `ObservableCollection`.

**What might this PR break?**

N/A

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

