### PR TITLE
Add use of dependent source generator to the Readme (#318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ public partial class MyReactiveClass : ReactiveObject
 }
 ```
 
+### Usage Reactive property with other source generators
+
+Roslyn source generators don’t have a defined run order and each generator sees the same initial compilation.
+Code/attributes that one generator emits aren’t visible to other generators in the same compilation round,
+so adding `[JsonPropertyName]`/`[JsonInclude]` from `ReactiveUI.SourceGenerators` won’t cause the `System.Text.Json`
+source generator to pick them up in that project. That’s by design of the generator pipeline (no inter-generator dependencies / ordering).
+
+So `System.Text.Json` needs special care. In the case that you want to Json-serialize `[Reactive]`
+properties, and you want to use the `System.Text.Json` source generator they must run in different
+assemblies. The same applies to other source generators depending on the output of `ReactiveUI.SourceGenerators`.
+
+Define types with `[Reactive]` properties in assembly `A`, and then define the
+`System.Text.Json.JsonSerializerContext` source generation context in assembly `B`, and let
+`B` reference `A`.
+
 ## Usage ObservableAsPropertyHelper `[ObservableAsProperty]`
 
 ObservableAsPropertyHelper is used to create a read-only property from an IObservable. The generated code will create a backing field and a property that returns the value of the backing field. The backing field is initialized with the value of the IObservable when the class is instantiated.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This is a small update to the Readme, based on the discussion System.Text.Json-attribute support #318 concerning how to use ReactiveUI.SourceGenerators with other source generators, specifically System.Text.Json.

**What is the current behavior?**
There is no mention of this little caveat, possibly causing confusion and increased support work load for the maintainers.

**What is the new behavior?**
A brief section explaining the background of Roslyn source generator limitations concerning inter-dependencies, and short explanation of how to work around this by placing the dependency source generator in a separate assembly.

**What might this PR break?**
It's just text in the Readme, so it's unlikely to break anything.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features) - N/A
- [x] Docs have been added / updated (for bug fixes / features) - Check.

**Other information**: N/A

