### PR TITLE
Housekeeping Update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) ReactiveUI and contributors 2023-2025
+Copyright (c) ReactiveUI and contributors 2023-2026
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/ReactiveUI.SourceGenerator.Tests/AssemblyInfo.Parallel.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/AssemblyInfo.Parallel.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/DERIVEDLIST/BindableDerivedListGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/DERIVEDLIST/BindableDerivedListGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/DERIVEDLIST/ReactiveCollectionGeneratorTests.FromReactiveCollectionField#ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/DERIVEDLIST/ReactiveCollectionGeneratorTests.FromReactiveCollectionField#ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.BindableDerivedListAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/IVIEWFOR/IViewForGeneratorTests.FromIViewFor#ReactiveUI.SourceGenerators.IViewForAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/IVIEWFOR/IViewForGeneratorTests.FromIViewFor#ReactiveUI.SourceGenerators.IViewForAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.IViewForAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/ModuleInitializer.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/ModuleInitializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethods#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableMethodsWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservableProp#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropNestedClasses#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttribute#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeNullableRef#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeNullableRef#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeRef#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithAttributeRef#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromObservablePropertiesWithName#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPFromObservableGeneratorTests.FromPartialProperty#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.FromFieldNestedClass#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NamedFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromField#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromFieldProtected#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/OAPH/OAPGeneratorTests.NonReadOnlyFromFieldProtected#ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ObservableAsPropertyAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveFromPartialWithAlsoNotify#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveFromPartialWithAlsoNotify#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveFromPartialWithAlsoNotify#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveFromPartialWithAlsoNotify#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePartialProperties#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePartialProperties#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePartialProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePartialProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperiesWithAttributes#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactiveProperties#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesCalledValue#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAccess#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithAttributesAccessAndInheritance#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithIdenticalClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithInit#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#ReactiveUI.SourceGenerators.AccessModifier.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.AccessModifier.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVE/ReactiveGeneratorTests.FromReactivePropertiesWithNestedClass#ReactiveUI.SourceGenerators.ReactiveAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveAsyncCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommand#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithAccessModifier#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithAccessModifier#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithNestedClasses#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithNestedClasses#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithNullableTypeAndNullableReturnType#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithNullableTypeAndNullableReturnType#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithOutputScheduler#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithOutputScheduler#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECMD/ReactiveCMDGeneratorTests.FromReactiveCommandWithParameter#ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCommandAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVECOLL/ReactiveCollectionGeneratorTests.FromReactiveCollectionField#ReactiveUI.SourceGenerators.ReactiveCollectionAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVECOLL/ReactiveCollectionGeneratorTests.FromReactiveCollectionField#ReactiveUI.SourceGenerators.ReactiveCollectionAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.ReactiveCollectionAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/REACTIVEOBJ/ReactiveObjectGeneratorTests.FromReactiveObject#ReactiveUI.SourceGenerators.IReactiveObjectAttribute.g.verified.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/REACTIVEOBJ/ReactiveObjectGeneratorTests.FromReactiveObject#ReactiveUI.SourceGenerators.IReactiveObjectAttribute.g.verified.cs
@@ -1,5 +1,5 @@
 ﻿//HintName: ReactiveUI.SourceGenerators.IReactiveObjectAttribute.g.cs
-// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/TestBase.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/TestBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/TestHelper.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/TestHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/BindableDerivedListGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/BindableDerivedListGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/IViewForGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/IViewForGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPFromObservableGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPFromObservableGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/OAPGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCollectionGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCollectionGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveObjectGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveObjectGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/FieldSyntaxExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/FieldSyntaxExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ISymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ISymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Extensions/ITypeSymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/EquatableArray{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/EquatableArray{T}.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/HashCode.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/HashCode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Core/Helpers/ImmutableArrayBuilder{T}.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldAnalyzer.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldCodeFixProvider.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/CodeFixers/PropertyToReactiveFieldCodeFixProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators.Analyzers.CodeFixes/Diagnostics/DiagnosticDescriptors.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute.Maui/IViewForTest.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Maui/IViewForTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute.Maui/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Maui/TestViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested1/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested1/Class1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested2/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested2/Class1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested3/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested3/Class1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute.Nested3/Nested4/Class1.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute.Nested3/Nested4/Class1.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/InternalTestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/InternalTestViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/Person.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/Person.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/Program.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestAttribute.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestClassOAPH_VM.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel2.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel3.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel3.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel{partTwo}.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel{partTwo}.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWinForms.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWinForms.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf2.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewWpf2.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsRCHost.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsRCHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsVMCHost.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestWinFormsVMCHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/AttributeDefinitions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2026 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/BindableDerivedListGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/Models/BindableDerivedListInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/BindableDerivedList/Models/BindableDerivedListInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/AttributeDataExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/AttributeDataExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/CompilationExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/CompilationExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/DiagnosticsExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/DiagnosticsExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/FieldSyntaxExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/FieldSyntaxExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/INamedTypeSymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ISymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ISymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ITypeSymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SymbolInfoExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SymbolInfoExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxTokenExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxTokenExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxValueProviderExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/SyntaxValueProviderExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/AttributeInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/AttributeInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/EquatableArray{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/EquatableArray{T}.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/HashCode.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/HashCode.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/ImmutableArrayBuilder{T}.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/SymbolHelpers.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/SymbolHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.Factory.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.Factory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Helpers/TypedConstantInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/DiagnosticInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/DiagnosticInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/GenericGeneratorAttributeSyntaxContext.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/GenericGeneratorAttributeSyntaxContext.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/PropertyAttributeData.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/PropertyAttributeData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/Result.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/Result.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/TargetInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Models/TargetInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/DiagnosticDescriptors.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/SuppressionDescriptors.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/SuppressionDescriptors.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/OAPHMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/OAPHMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ObservableAsPropertyAttributeWithFieldNeverReadDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ObservableAsPropertyAttributeWithFieldNeverReadDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithFieldTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithFieldTargetDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithPropertyTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveAttributeWithPropertyTargetDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandAttributeWithFieldOrPropertyTargetDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandAttributeWithFieldOrPropertyTargetDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveCommandMethodDoesNotNeedToBeStaticDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveFieldDoesNotNeedToBeReadOnlyDiagnosticSuppressor.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Diagnostics/Suppressions/ReactiveFieldDoesNotNeedToBeReadOnlyDiagnosticSuppressor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForBaseType.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForBaseType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableFieldInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableFieldInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableMethodInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableMethodInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/Models/ReactiveCollectionFieldInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/Models/ReactiveCollectionFieldInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/ReactiveCollectionGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/ReactiveCollectionGenerator.Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/ReactiveCollectionGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/ReactiveCollectionGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CanExecuteTypeInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CanExecuteTypeInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CommandInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CommandInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveObject/Models/ReactiveObjectInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveObject/Models/ReactiveObjectInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveObject/ReactiveObjectGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveObject/ReactiveObjectGenerator.Execute.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveObject/ReactiveObjectGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveObject/ReactiveObjectGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/Models/RoutedControlHostInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/Models/RoutedControlHostInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/Models/ViewModelControlHostInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/Models/ViewModelControlHostInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+﻿// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 ReactiveUI and contributors. All rights reserved.
+// Copyright (c) 2026 ReactiveUI and contributors. All rights reserved.
 // Licensed to the ReactiveUI and contributors under one or more agreements.
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.

--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -13,7 +13,7 @@
             "documentPrivateFields": false,
             "documentationCulture": "en-US",
             "companyName": "ReactiveUI and contributors",
-            "copyrightText": "Copyright (c) 2025 {companyName}. All rights reserved.\nLicensed to the {companyName} under one or more agreements.\nThe {companyName} licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
+            "copyrightText": "Copyright (c) 2026 {companyName}. All rights reserved.\nLicensed to the {companyName} under one or more agreements.\nThe {companyName} licenses this file to you under the {licenseName} license.\nSee the {licenseFile} file in the project root for full license information.",
             "variables": {
                 "licenseName": "MIT",
                 "licenseFile": "LICENSE"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Updated copyright notices from 2025 to 2026 across source files, test files, and generated code to reflect the new year. No functional code changes were made.