### PR TITLE
Refactor model namespaces and update imports

### DIFF
--- a/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
+++ b/src/ReactiveUI.SourceGenerators.Execute/TestViewModel.cs
@@ -7,7 +7,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reactive;
 using System.Reactive.Concurrency;
-using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -16,7 +15,6 @@ using System.Text.Json.Serialization;
 using DynamicData;
 using ReactiveUI;
 using ReactiveUI.SourceGenerators;
-using SGReactiveUI.SourceGenerators.Execute.Nested3;
 
 namespace SGReactiveUI.SourceGenerators.Test;
 

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.Execute.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Input.Models;
 using ReactiveUI.SourceGenerators.Models;
 
 namespace ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/IViewForGenerator.cs
@@ -49,7 +49,7 @@ public sealed partial class IViewForGenerator : IIncrementalGenerator
             if (groupedPropertyInfo.Length == 0)
             {
                 // Even if there are no views, emit an empty extension to keep API stable.
-                var empty = GenerateRegistrationExtensions(ImmutableArray.Create<Input.Models.IViewForInfo>());
+                var empty = GenerateRegistrationExtensions(ImmutableArray.Create<Models.IViewForInfo>());
                 context.AddSource(fileName, SourceText.From(empty, Encoding.UTF8));
                 return;
             }

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForBaseType.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForBaseType.cs
@@ -3,7 +3,7 @@
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace ReactiveUI.SourceGenerators.Input.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 internal enum IViewForBaseType
 {

--- a/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/IViewFor/Models/IViewForInfo.cs
@@ -3,9 +3,7 @@
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.SourceGenerators.Models;
-
-namespace ReactiveUI.SourceGenerators.Input.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 /// <summary>
 /// A model with gathered info on a given command method.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableFieldInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableFieldInfo.cs
@@ -4,9 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Models;
 
-namespace ReactiveUI.SourceGenerators.Reactive.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 /// <summary>
 /// A model with gathered info on a given field.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableMethodInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/Models/ObservableMethodInfo.cs
@@ -5,9 +5,8 @@
 
 using System.Globalization;
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Models;
 
-namespace ReactiveUI.SourceGenerators.ObservableAsProperty.Models
+namespace ReactiveUI.SourceGenerators.Models
 {
     internal record ObservableMethodInfo(
         TargetInfo TargetInfo,

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromField}.Execute.cs
@@ -4,16 +4,13 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 using ReactiveUI.SourceGenerators.Models;
-using ReactiveUI.SourceGenerators.Reactive.Models;
 using static ReactiveUI.SourceGenerators.Diagnostics.DiagnosticDescriptors;
 
 namespace ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ObservableAsProperty/ObservableAsPropertyGenerator{FromObservable}.Execute.cs
@@ -3,7 +3,6 @@
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -11,7 +10,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 using ReactiveUI.SourceGenerators.Models;
-using ReactiveUI.SourceGenerators.ObservableAsProperty.Models;
 using static ReactiveUI.SourceGenerators.Diagnostics.DiagnosticDescriptors;
 
 namespace ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/Models/PropertyInfo.cs
@@ -4,9 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Models;
 
-namespace ReactiveUI.SourceGenerators.Reactive.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 /// <summary>
 /// A model with gathered info on a given field.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Reactive/ReactiveGenerator.Execute.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 using ReactiveUI.SourceGenerators.Models;
-using ReactiveUI.SourceGenerators.Reactive.Models;
 using static ReactiveUI.SourceGenerators.Diagnostics.DiagnosticDescriptors;
 
 namespace ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/Models/ReactiveCollectionFieldInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/Models/ReactiveCollectionFieldInfo.cs
@@ -4,9 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Models;
 
-namespace ReactiveUI.SourceGenerators.Reactive.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 /// <summary>
 /// A model with gathered info on a given field.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/ReactiveCollectionGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCollection/ReactiveCollectionGenerator.Execute.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 using ReactiveUI.SourceGenerators.Models;
-using ReactiveUI.SourceGenerators.Reactive.Models;
 using static ReactiveUI.SourceGenerators.Diagnostics.DiagnosticDescriptors;
 
 namespace ReactiveUI.SourceGenerators;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CanExecuteTypeInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CanExecuteTypeInfo.cs
@@ -3,7 +3,7 @@
 // The ReactiveUI and contributors licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace ReactiveUI.SourceGenerators.Input.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 internal enum CanExecuteTypeInfo
 {

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CommandInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/Models/CommandInfo.cs
@@ -4,9 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Models;
 
-namespace ReactiveUI.SourceGenerators.Input.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 internal record CommandInfo(
     TargetInfo TargetInfo,

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ReactiveCommand/ReactiveCommandGenerator.Execute.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Input.Models;
 using ReactiveUI.SourceGenerators.Models;
 
 namespace ReactiveUI.SourceGenerators;
@@ -27,7 +26,7 @@ public partial class ReactiveCommandGenerator
     internal static readonly string GeneratorName = typeof(ReactiveCommandGenerator).FullName!;
     internal static readonly string GeneratorVersion = typeof(ReactiveCommandGenerator).Assembly.GetName().Version.ToString();
 
-    private const string ReactiveUI = "ReactiveUI";
+    private const string ReactiveUI = "global::ReactiveUI";
     private const string ReactiveCommand = "ReactiveCommand";
     private const string RxCmd = ReactiveUI + "." + ReactiveCommand;
     private const string Create = ".Create";
@@ -35,8 +34,8 @@ public partial class ReactiveCommandGenerator
     private const string CreateT = ".CreateFromTask";
     private const string CanExecute = "CanExecute";
     private const string OutputScheduler = "OutputScheduler";
-    private const string MainThreadScheduler = "RxSchedulers.MainThreadScheduler";
-    private const string TaskpoolScheduler = "RxSchedulers.TaskpoolScheduler";
+    private const string MainThreadScheduler = ReactiveUI + ".RxSchedulers.MainThreadScheduler";
+    private const string TaskpoolScheduler = ReactiveUI + ".RxSchedulers.TaskpoolScheduler";
 
     private static CommandInfo? GetMethodInfo(in GeneratorAttributeSyntaxContext context, CancellationToken token)
     {

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/Models/RoutedControlHostInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/Models/RoutedControlHostInfo.cs
@@ -5,7 +5,7 @@
 
 using ReactiveUI.SourceGenerators.Helpers;
 
-namespace ReactiveUI.SourceGenerators.Input.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 /// <summary>
 /// A model with gathered info on a given command method.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Input.Models;
 using ReactiveUI.SourceGenerators.Models;
 
 namespace ReactiveUI.SourceGenerators.WinForms;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
@@ -9,7 +9,6 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
-using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 
 namespace ReactiveUI.SourceGenerators.WinForms;

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/Models/ViewModelControlHostInfo.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/Models/ViewModelControlHostInfo.cs
@@ -5,7 +5,7 @@
 
 using ReactiveUI.SourceGenerators.Helpers;
 
-namespace ReactiveUI.SourceGenerators.Input.Models;
+namespace ReactiveUI.SourceGenerators.Models;
 
 /// <summary>
 /// A model with gathered info on a given command method.

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
-using ReactiveUI.SourceGenerators.Input.Models;
 using ReactiveUI.SourceGenerators.Models;
 
 namespace ReactiveUI.SourceGenerators.WinForms;


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fixes #351 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

#351 

**What is the new behavior?**
<!-- If this is a feature change -->

Moved several model classes from 'ReactiveUI.SourceGenerators.Input.Models', 'ReactiveUI.SourceGenerators.Reactive.Models', and 'ReactiveUI.SourceGenerators.ObservableAsProperty.Models' to 'ReactiveUI.SourceGenerators.Models'. 

Updated all related using statements and namespace declarations to reflect this change. 

Also updated references to ReactiveCommand and RxSchedulers in ReactiveCommandGenerator for clarity and global namespace usage. 
This improves code organization and consistency across source generators.

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

