### PR TITLE
Bump ReactiveUI to V23 and adapt generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This documentation covers using ReactiveUI Source Generators to simplify and enh
   - **ReactiveUI Version**: 19.5.31+
 
 ## Table of Contents
+- [Installation](#installation)
 - [Overview](#overview)
 - [Supported Attributes & Features](#supported-attributes)
 - [Detailed Usage](#welcome-to-a-new-way---source-generators)
@@ -19,6 +20,12 @@ This documentation covers using ReactiveUI Source Generators to simplify and enh
   - [Platform-Specific Attributes](#platform-specific-attributes)
 - [Compatibility Notes](#compatibility-notes)
 - [Credits](#credits)
+
+## Installation
+
+dotnet add package ReactiveUI.SourceGenerators
+
+Ensure the package is loaded with `PrivateAssets="all"` to avoid issues with generated code in consuming projects.
 
 ## Overview
 
@@ -35,7 +42,7 @@ ReactiveUI Source Generators automatically generate ReactiveUI objects to stream
 - `[ObservableAsProperty(InitialValue = "Default Value")]` Only valid for partial properties using (C# 13 Visual Studio Version 17.12.0)
 - `[ReactiveCommand]`
 - `[ReactiveCommand(CanExecute = nameof(IObservableBoolName))]` with CanExecute
-- `[ReactiveCommand(OutputScheduler = "RxApp.MainThreadScheduler")]` using a ReactiveUI Scheduler
+- `[ReactiveCommand(OutputScheduler = "RxSchedulers.MainThreadScheduler")]` using a ReactiveUI Scheduler
 - `[ReactiveCommand(OutputScheduler = nameof(_isheduler))]` using a Scheduler defined in the class
 - `[ReactiveCommand][property: AttributeToAddToCommand]` with Attribute passthrough
 - `[ReactiveCommand(AccessModifier = PropertyAccessModifier.Internal)]` sets the access modifier of the generated command property
@@ -547,7 +554,7 @@ using ReactiveUI.SourceGenerators;
 
 public partial class MyReactiveClass
 {
-    [ReactiveCommand(OutputScheduler = "RxApp.MainThreadScheduler")]
+    [ReactiveCommand(OutputScheduler = "RxSchedulers.MainThreadScheduler")]
     private void Execute() { }
 }
 ```

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Splat" Version="19.3.1" />
     <PackageVersion Include="stylecop.analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="ReactiveUI" Version="22.3.1" />
+    <PackageVersion Include="ReactiveUI" Version="23.2.1" />
     <PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/ReactiveCMDGeneratorTests.cs
@@ -148,7 +148,7 @@ public class ReactiveCMDGeneratorTests : TestBase<ReactiveCommandGenerator>
                 namespace TestNs;
                 public partial class TestVM : ReactiveObject
                 {
-                    [ReactiveCommand(OutputScheduler = "RxApp.MainThreadScheduler")]
+                    [ReactiveCommand(OutputScheduler = "RxSchedulers.MainThreadScheduler")]
                     private int Test1() => 10;
                 }
             """;

--- a/src/ReactiveUI.SourceGenerator.Tests/UnitTests/RxCmdExtTests.cs
+++ b/src/ReactiveUI.SourceGenerator.Tests/UnitTests/RxCmdExtTests.cs
@@ -462,7 +462,7 @@ public class RxCmdExtTests : TestBase<ReactiveCommandGenerator>
             {
                 public IObservable<bool> CanExecuteCommand => Observable.Return(true);
 
-                [ReactiveCommand(CanExecute = nameof(CanExecuteCommand), OutputScheduler = "RxApp.MainThreadScheduler")]
+                [ReactiveCommand(CanExecute = nameof(CanExecuteCommand), OutputScheduler = "RxScheduler.MainThreadScheduler")]
                 private async Task<string> ExecuteWithScheduler()
                 {
                     await Task.Delay(100);

--- a/src/ReactiveUI.SourceGenerators.Execute/ReactiveUI.SourceGenerators.Execute.csproj
+++ b/src/ReactiveUI.SourceGenerators.Execute/ReactiveUI.SourceGenerators.Execute.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
@@ -21,6 +21,6 @@
   <ItemGroup>
     <ProjectReference Include="..\ReactiveUI.SourceGenerators.Analyzers.CodeFixes\ReactiveUI.SourceGenerators.Analyzers.CodeFixes.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\ReactiveUI.SourceGenerators.Execute.Nested3\ReactiveUI.SourceGenerators.Execute.Nested3.csproj" />
-    <ProjectReference Include="..\ReactiveUI.SourceGenerators.Roslyn4120\ReactiveUI.SourceGenerators.Roslyn4120.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\ReactiveUI.SourceGenerators.Roslyn5000\ReactiveUI.SourceGenerators.Roslyn5000.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/src/ReactiveUI.SourceGenerators.Roslyn/AttributeDefinitions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/AttributeDefinitions.cs
@@ -13,8 +13,9 @@ internal static class AttributeDefinitions
 {
     public const string GeneratedCode = "global::System.CodeDom.Compiler.GeneratedCode";
     public const string Obsolete = "global::System.Obsolete";
-
     public const string AccessModifierType = "ReactiveUI.SourceGenerators.AccessModifier";
+    public const string ReactiveUI = "ReactiveUI";
+
     public static string[] ExcludeFromCodeCoverage = ["[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]"];
 
     public static string GetAccessModifierEnum() => $$"""

--- a/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/Core/Extensions/ContextExtensions.cs
@@ -111,4 +111,11 @@ internal static class ContextExtensions
         var attributes = forwardedAttributeBuilder.ToImmutable();
         forwardedAttributes = attributes.Select(static a => a.ToString()).ToImmutableArray();
     }
+
+    internal static IncrementalValueProvider<bool> ReactiveUIVersionIsGreaterThan22(this in IncrementalGeneratorInitializationContext context) =>
+        context.CompilationProvider.Select(static (compilation, token) =>
+        {
+            token.ThrowIfCancellationRequested();
+            return compilation.ReferencedAssemblyNames.FirstOrDefault(a => a.Name == AttributeDefinitions.ReactiveUI)?.Version.Major > 22;
+        });
 }

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.Execute.cs
@@ -80,10 +80,13 @@ public partial class RoutedControlHostGenerator
             classAttributesInfo);
     }
 
-    private static string GetRoutedControlHost(string containingTypeName, string containingNamespace, string containingClassVisibility, string containingType, RoutedControlHostInfo vmcInfo)
+    private static string GetRoutedControlHost(string containingTypeName, string containingNamespace, string containingClassVisibility, string containingType, RoutedControlHostInfo vmcInfo, bool isNewerThan22)
     {
         // Prepare any forwarded property attributes
         var forwardedAttributesString = string.Join("\n        ", AttributeDefinitions.ExcludeFromCodeCoverage.Concat(vmcInfo.ForwardedAttributes));
+        var exceptionHandler = isNewerThan22
+            ? "RxState.DefaultExceptionHandler!.OnNext"
+            : "RxApp.DefaultExceptionHandler!.OnNext";
 
         return
 $$"""
@@ -162,7 +165,7 @@ namespace {{containingNamespace}}
                 }
 
                 ResumeLayout();
-            }, RxApp.DefaultExceptionHandler!.OnNext));
+            }, {{exceptionHandler}}));
         }
 
         /// <inheritdoc/>

--- a/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/RoutedControlHost/RoutedControlHostGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 
 namespace ReactiveUI.SourceGenerators.WinForms;
@@ -25,6 +26,8 @@ public sealed partial class RoutedControlHostGenerator : IIncrementalGenerator
         context.RegisterPostInitializationOutput(ctx =>
             ctx.AddSource($"{AttributeDefinitions.RoutedControlHostAttributeType}.g.cs", SourceText.From(AttributeDefinitions.GetRoutedControlHostAttribute(), Encoding.UTF8)));
 
+        var reactiveUiVersionProvider = context.ReactiveUIVersionIsGreaterThan22();
+
         // Gather info for all annotated IViewFor Classes
         var rchInfo =
             context.SyntaxProvider
@@ -34,12 +37,13 @@ public sealed partial class RoutedControlHostGenerator : IIncrementalGenerator
                 static (context, token) => GetClassInfo(context, token))
             .Where(x => x != null)
             .Select((x, _) => x!)
-            .Collect();
+            .Collect()
+            .Combine(reactiveUiVersionProvider);
 
         // Generate the requested properties and methods for IViewFor
         context.RegisterSourceOutput(rchInfo, static (context, input) =>
         {
-            var groupedPropertyInfo = input.GroupBy(
+            var groupedPropertyInfo = input.Left.GroupBy(
                 static info => (info.FileHintName, info.TargetName, info.TargetNamespace, info.TargetVisibility, info.TargetType),
                 static info => info)
                 .ToImmutableArray();
@@ -58,7 +62,7 @@ public sealed partial class RoutedControlHostGenerator : IIncrementalGenerator
                     continue;
                 }
 
-                var source = GetRoutedControlHost(grouping.Key.TargetName, grouping.Key.TargetNamespace, grouping.Key.TargetVisibility, grouping.Key.TargetType, grouping.FirstOrDefault());
+                var source = GetRoutedControlHost(grouping.Key.TargetName, grouping.Key.TargetNamespace, grouping.Key.TargetVisibility, grouping.Key.TargetType, grouping.FirstOrDefault(), input.Right);
                 context.AddSource($"{grouping.Key.FileHintName}.RoutedControlHost.g.cs", source);
             }
         });

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.Execute.cs
@@ -73,10 +73,13 @@ public partial class ViewModelControlHostGenerator
             classAttributesInfo);
     }
 
-    private static string GetViewModelControlHost(string containingTypeName, string containingNamespace, string containingClassVisibility, string containingType, ViewModelControlHostInfo vmcInfo)
+    private static string GetViewModelControlHost(string containingTypeName, string containingNamespace, string containingClassVisibility, string containingType, ViewModelControlHostInfo vmcInfo, bool isNewerThan22)
     {
         // Prepare any forwarded property attributes
         var forwardedAttributesString = string.Join("\n        ", AttributeDefinitions.ExcludeFromCodeCoverage.Concat(vmcInfo.ForwardedAttributes));
+        var exceptionHandler = isNewerThan22
+            ? "RxState.DefaultExceptionHandler!.OnNext"
+            : "RxApp.DefaultExceptionHandler!.OnNext";
 
         return
 $$"""
@@ -263,7 +266,7 @@ namespace {{containingNamespace}}
                     view.ViewModel = x.ViewModel;
                     Content = view;
                 }
-            }, RxApp.DefaultExceptionHandler!.OnNext);
+            }, {{exceptionHandler}});
         }
     }
 }

--- a/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.cs
+++ b/src/ReactiveUI.SourceGenerators.Roslyn/ViewModelControlHost/ViewModelControlHostGenerator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using ReactiveUI.SourceGenerators.Extensions;
 using ReactiveUI.SourceGenerators.Helpers;
 
 namespace ReactiveUI.SourceGenerators.WinForms;
@@ -25,6 +26,8 @@ public sealed partial class ViewModelControlHostGenerator : IIncrementalGenerato
         context.RegisterPostInitializationOutput(ctx =>
             ctx.AddSource($"{AttributeDefinitions.ViewModelControlHostAttributeType}.g.cs", SourceText.From(AttributeDefinitions.ViewModelControlHostAttribute, Encoding.UTF8)));
 
+        var reactiveUiVersionProvider = context.ReactiveUIVersionIsGreaterThan22();
+
         // Gather info for all annotated IViewFor Classes
         var vmcInfo =
             context.SyntaxProvider
@@ -34,12 +37,13 @@ public sealed partial class ViewModelControlHostGenerator : IIncrementalGenerato
                 static (context, token) => GetClassInfo(context, token))
             .Where(x => x != null)
             .Select((x, _) => x!)
-            .Collect();
+            .Collect()
+            .Combine(reactiveUiVersionProvider);
 
         // Generate the requested properties and methods for IViewFor
         context.RegisterSourceOutput(vmcInfo, static (context, input) =>
         {
-            var groupedPropertyInfo = input.GroupBy(
+            var groupedPropertyInfo = input.Left.GroupBy(
                 static info => (info.FileHintName, info.TargetName, info.TargetNamespace, info.TargetVisibility, info.TargetType),
                 static info => info)
                 .ToImmutableArray();
@@ -58,7 +62,7 @@ public sealed partial class ViewModelControlHostGenerator : IIncrementalGenerato
                     continue;
                 }
 
-                var source = GetViewModelControlHost(grouping.Key.TargetName, grouping.Key.TargetNamespace, grouping.Key.TargetVisibility, grouping.Key.TargetType, grouping.FirstOrDefault());
+                var source = GetViewModelControlHost(grouping.Key.TargetName, grouping.Key.TargetNamespace, grouping.Key.TargetVisibility, grouping.Key.TargetType, grouping.FirstOrDefault(), input.Right);
                 context.AddSource($"{grouping.Key.FileHintName}.ViewModelControlHost.g.cs", source);
             }
         });


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Supports up to ReactiveUI V22.X.X

**What is the new behavior?**
<!-- If this is a feature change -->

Upgrade ReactiveUI support to include 23.X.X+ and update generators, tests, and docs to match API changes.

Added a ReactiveUI version check provider and switched generated code to use RxState.DefaultExceptionHandler when ReactiveUI > 22 (falling back to RxApp.DefaultExceptionHandler otherwise). 

Updated generator wiring to combine the version provider, adjusted generated scheduler references in tests and README (RxSchedulers.MainThreadScheduler), bumped the console project's TargetFramework to net10.0 and switched a Roslyn analyzer project reference to the new Roslyn5000 project. 

Also added an Installation section to the README and minor attribute/definition adjustments. fixes #382

**What might this PR break?**

None expected, resolves a potential issue for users of ReactiveUI V23+

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

